### PR TITLE
Allow choice of apache or nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ CLI](docs/Deploy.md).
 ## What this stack will give you
 
 This template set deploys the following infrastructure:
-- Autoscaling web frontend layer (Nginx, php-fpm, Varnish)
+- Autoscaling web frontend layer (Nginx for https termination, Varnish for caching, Nginx/php-fpm or Apache/php)
 - Private virtual network for frontend instances
 - Controller instance running cron and handling syslog for the autoscaled site
 - Load balancer to balance across the autoscaled instances

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -515,8 +515,8 @@
         "documentation10": "    controller          - creates a jumpbox and deploys code",
         "documentation11": "GlusterFS Sizing guidance",
         "moodleCommon": {
-            "baseTemplateUrl": "https://raw.githubusercontent.com/hosungsmsft/Moodle/master/nested/",
-            "scriptLocation": "https://raw.githubusercontent.com/hosungsmsft/Moodle/master/scripts/",
+            "baseTemplateUrl": "https://raw.githubusercontent.com/Azure/Moodle/master/nested/",
+            "scriptLocation": "https://raw.githubusercontent.com/Azure/Moodle/master/scripts/",
 
             "applyScriptsSwitch": "[parameters('applyScriptsSwitch')]",
             "autoscaleVmCount": "[parameters('autoscaleVmCount')]",

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -48,6 +48,17 @@
             },
             "type": "string"
         },
+        "webServerType": {
+            "defaultValue": "apache",
+            "allowedValues": [
+                "apache",
+                "nginx"
+            ],
+            "metadata": {
+                "description": "Web server type"
+            },
+            "type": "string"
+        },
         "controllerVmSku": {
             "defaultValue": "Standard_DS1_v2",
             "metadata": {
@@ -606,7 +617,8 @@
             "vmssName": "[concat('vmss-',variables('resourceprefix'))]",
             "vmssdStorageAccounttName": "[concat('vmss',uniqueString(resourceGroup().id))]",
             "vnetName": "[concat('vnet-',variables('resourceprefix'))]",
-            "vpnType": "[parameters('vpnType')]"
+            "vpnType": "[parameters('vpnType')]",
+            "webServerType": "[parameters('webServerType')]"
         },
         "octets": "[split(parameters('vNetAddressSpace'), '.')]",
         "resourceprefix": "[substring(uniqueString(resourceGroup().id, deployment().name), 3, 6)]"

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -515,8 +515,8 @@
         "documentation10": "    controller          - creates a jumpbox and deploys code",
         "documentation11": "GlusterFS Sizing guidance",
         "moodleCommon": {
-            "baseTemplateUrl": "https://raw.githubusercontent.com/Azure/Moodle/master/nested/",
-            "scriptLocation": "https://raw.githubusercontent.com/Azure/Moodle/master/scripts/",
+            "baseTemplateUrl": "https://raw.githubusercontent.com/hosungsmsft/Moodle/master/nested/",
+            "scriptLocation": "https://raw.githubusercontent.com/hosungsmsft/Moodle/master/scripts/",
 
             "applyScriptsSwitch": "[parameters('applyScriptsSwitch')]",
             "autoscaleVmCount": "[parameters('autoscaleVmCount')]",

--- a/azuredeploy.parameters.json
+++ b/azuredeploy.parameters.json
@@ -8,6 +8,7 @@
                 "blobStorageAccountType":      { "value": "Standard_LRS"},
                 "controllerVmSku":             { "value": "Standard_DS1_v2" },
                 "dbServerType":                { "value": "postgres" },
+                "webServerType":               { "value": "apache" },
                 "elasticVmSku":                { "value": "Standard_DS2_v2" },
                 "glusterDiskCount":            { "value": 4 },
                 "glusterDiskSize":             { "value": 127 },

--- a/nested/webvmss.json
+++ b/nested/webvmss.json
@@ -197,7 +197,7 @@
         }
     ],
     "variables": {
-        "cmdExec": "[concat('bash ',parameters('moodleCommon').moodleSetupScriptFilename,' ',parameters('moodleCommon').gfsNameRoot,'0', ' ','data', ' ', parameters('moodleCommon').siteURL, ' ', concat('jumpbox-vm-',parameters('moodleCommon').resourcesPrefix))]",
+        "cmdExec": "[concat('bash ',parameters('moodleCommon').moodleSetupScriptFilename,' ',parameters('moodleCommon').gfsNameRoot,'0', ' ','data', ' ', parameters('moodleCommon').siteURL, ' ', concat('jumpbox-vm-',parameters('moodleCommon').resourcesPrefix), ' ', parameters('moodleCommon').webServerType)]",
         "dstorID": "[resourceId('Microsoft.Storage/storageAccounts',parameters('moodleCommon').vmssdStorageAccounttName)]",
         "extBeID": "[concat(variables('extLbID'),'/backendAddressPools/',parameters('moodleCommon').extBeName)]",
         "extFeID": "[concat(variables('extLbID'),'/frontendIPConfigurations/',parameters('moodleCommon').extFeName)]",

--- a/nested/webvmssconfig1.json
+++ b/nested/webvmssconfig1.json
@@ -34,7 +34,7 @@
 
     ],
     "variables": {
-        "cmdExec": "[concat('bash ',parameters('moodleCommon').moodleSetupScriptFilename,' ',parameters('moodleCommon').gfsNameRoot,'0', ' ','data', ' ', parameters('moodleCommon').siteURL, ' ', concat('jumpbox-vm-',parameters('moodleCommon').resourcesPrefix))]",
+        "cmdExec": "[concat('bash ',parameters('moodleCommon').moodleSetupScriptFilename,' ',parameters('moodleCommon').gfsNameRoot,'0', ' ','data', ' ', parameters('moodleCommon').siteURL, ' ', concat('jumpbox-vm-',parameters('moodleCommon').resourcesPrefix), ' ', parameters('moodleCommon').webServerType)]",
         "scriptUri": "[concat(parameters('moodleCommon').ScriptLocation,parameters('moodleCommon').moodleSetupScriptFilename)]"
     }
 }

--- a/scripts/setup_moodle.sh
+++ b/scripts/setup_moodle.sh
@@ -246,8 +246,8 @@ EOF
 		Require all granted
 	</Directory>
 
-	ErrorLog \${APACHE_LOG_DIR}/error.log
-	CustomLog \${APACHE_LOG_DIR}/access.log combined combined
+	ErrorLog "|/usr/bin/logger -t moodle -p local1.error"
+	CustomLog "|/usr/bin/logger -t moodle -p local1.notice" combined
 
 </VirtualHost>
 EOF

--- a/scripts/setup_moodle.sh
+++ b/scripts/setup_moodle.sh
@@ -26,10 +26,13 @@ glusterNode=$1
 glusterVolume=$2 
 siteFQDN=$3
 syslogserver=$4
+webServerType=$5
 
-echo $glusterNode    >> /tmp/vars.txt
+echo $glusterNode    > /tmp/vars.txt
 echo $glusterVolume  >> /tmp/vars.txt
 echo $siteFQDN >> /tmp/vars.txt
+echo $syslogserver >> /tmp/vars.txt
+echo $webServerType >> /tmp/vars.txt
 
 {
   # make sure the system does automatic update
@@ -45,7 +48,15 @@ echo $siteFQDN >> /tmp/vars.txt
   sudo apt-get -y install glusterfs-client postgresql-client mysql-client git
 
   # install the base stack
-  sudo apt-get -y install nginx php-fpm varnish php php-cli php-curl php-zip
+  sudo apt-get -y install nginx varnish php php-cli php-curl php-zip
+
+  if [ "$webServerType" = "apache" ]; then
+    # install apache pacakges
+    sudo apt-get -y install apache2 libapache2-mod-php
+  else
+    # for nginx-only option
+    sudo apt-get -y install php-fpm
+  fi
 
   # Moodle requirements
   sudo apt-get install -y graphviz aspell php-soap php-json php-redis php-bcmath php-gd php-pgsql php-mysql php-xmlrpc php-intl php-xml php-bz2
@@ -129,6 +140,7 @@ http {
 }
 EOF
 
+  if [ "$webServerType" = "nginx" ]; then
     cat <<EOF >> /etc/nginx/sites-enabled/${siteFQDN}.conf
 server {
         listen 81 default;
@@ -181,6 +193,10 @@ server {
         }
 }
 
+EOF
+  fi
+
+    cat <<EOF > /etc/nginx/sites-enabled/${siteFQDN}.conf
 server {
         listen 443 ssl;
         root /moodle/html/moodle;
@@ -214,8 +230,35 @@ server {
 }
 EOF
 
+ if [ "$webServerType" = "apache" ]; then
+   sed -i "s/Listen 80/Listen 81/" /etc/apache2/ports.conf
+
+   cat <<EOF > /etc/apache2/sites-enabled/${siteFQDN}.conf
+<VirtualHost *:81>
+	ServerName ${siteFQDN}
+
+	ServerAdmin webmaster@localhost
+	DocumentRoot /moodle/html/moodle
+
+	<Directory /moodle/html/moodle>
+		Options FollowSymLinks
+		AllowOverride All
+		Require all granted
+	</Directory>
+
+	ErrorLog "|/usr/bin/logger -t moodle -p local1.error"
+	CustomLog "|/usr/bin/logger -t moodle -p local1.notice" combined
+
+</VirtualHost>
+EOF
+  fi
+
    # php config 
-   PhpIni=/etc/php/7.0/fpm/php.ini
+   if [ "$webServerType" = "apache" ]; then
+     PhpIni=/etc/php/7.0/apache2/php.ini
+   else
+     PhpIni=/etc/php/7.0/fpm/php.ini
+   fi
    sed -i "s/memory_limit.*/memory_limit = 512M/" $PhpIni
    sed -i "s/max_execution_time.*/max_execution_time = 18000/" $PhpIni
    sed -i "s/max_input_vars.*/max_input_vars = 100000/" $PhpIni
@@ -232,12 +275,16 @@ EOF
     
    # Remove the default site. Moodle is the only site we want
    rm -f /etc/nginx/sites-enabled/default
+   if [ "$webServerType" = "apache" ]; then
+     rm -f /etc/apache2/sites-enabled/000-default.conf
+   fi
 
    # restart Nginx
    sudo service nginx restart 
 
-   # fpm config - overload this 
-   cat <<EOF > /etc/php/7.0/fpm/pool.d/www.conf
+   if [ "$webServerType" = "nginx" ]; then
+     # fpm config - overload this 
+     cat <<EOF > /etc/php/7.0/fpm/pool.d/www.conf
 [www]
 user = www-data
 group = www-data
@@ -251,15 +298,20 @@ pm.min_spare_servers = 20
 pm.max_spare_servers = 30 
 EOF
 
-   # Restart fpm
-   service php7.0-fpm restart
+     # Restart fpm
+     service php7.0-fpm restart
+   fi
+
+   if [ "$webServerType" = "apache" ]; then
+     sudo service apache2 restart
+   fi
 
    # Configure varnish startup for 16.04
    VARNISHSTART="ExecStart=\/usr\/sbin\/varnishd -j unix,user=vcache -F -a :80 -T localhost:6082 -f \/etc\/varnish\/moodle.vcl -S \/etc\/varnish\/secret -s malloc,1024m -p thread_pool_min=200 -p thread_pool_max=4000 -p thread_pool_add_delay=2 -p timeout_linger=100 -p timeout_idle=30 -p send_timeout=1800 -p thread_pools=4 -p http_max_hdr=512 -p workspace_backend=512k"
    sed -i "s/^ExecStart.*/${VARNISHSTART}/" /lib/systemd/system/varnish.service
 
    # Configure varnish VCL for moodle
-   cat <<EOF >> /etc/varnish/moodle.vcl
+   cat <<EOF > /etc/varnish/moodle.vcl
 vcl 4.0;
 
 import std;

--- a/scripts/setup_moodle.sh
+++ b/scripts/setup_moodle.sh
@@ -28,7 +28,7 @@ siteFQDN=$3
 syslogserver=$4
 webServerType=$5
 
-echo $glusterNode    > /tmp/vars.txt
+echo $glusterNode    >> /tmp/vars.txt
 echo $glusterVolume  >> /tmp/vars.txt
 echo $siteFQDN >> /tmp/vars.txt
 echo $syslogserver >> /tmp/vars.txt
@@ -311,7 +311,7 @@ EOF
    sed -i "s/^ExecStart.*/${VARNISHSTART}/" /lib/systemd/system/varnish.service
 
    # Configure varnish VCL for moodle
-   cat <<EOF > /etc/varnish/moodle.vcl
+   cat <<EOF >> /etc/varnish/moodle.vcl
 vcl 4.0;
 
 import std;


### PR DESCRIPTION
This is the correct/working update of the template to allow choice of apache or nginx for http web layer. Validated on all 4 combinations: MySQL/PostgresSQL x Apache/nginx.

A few more minor things to do:
- Redirect direct outside Apache http connection (to port 81) to https (443)
- Log correct IP address instead of 127.0.0.1 for Apache http (nginx http does that already)
