### PR TITLE
Update MySQL/PostgreSQL config params for latest API version and fix MS SQL param names

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo contains guides and [Azure Resource Manager](https://docs.microsoft.co
 If you have Azure account you can deploy Moodle via the [Azure portal](https://portal.azure.com) using the button below, or you can [deploy Moodle via the
 CLI](docs/Deploy.md). Please note that while you can use an [Azure free account](https://azure.microsoft.com/en-us/free/) to get started depending on which template configuration you choose you will likely be required to upgrade to a paid account.
 
-[![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FMoodle%2Fdb-sku-update%2Fazuredeploy.json)  [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.png)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FMoodle%2Fdb-sku-update%2Fazuredeploy.json)
+[![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FMoodle%2Fmaster%2Fazuredeploy.json)  [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.png)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FMoodle%2Fmaster%2Fazuredeploy.json)
 
 ## Stack Architecture
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo contains guides and [Azure Resource Manager](https://docs.microsoft.co
 If you have Azure account you can deploy Moodle via the [Azure portal](https://portal.azure.com) using the button below, or you can [deploy Moodle via the
 CLI](docs/Deploy.md). Please note that while you can use an [Azure free account](https://azure.microsoft.com/en-us/free/) to get started depending on which template configuration you choose you will likely be required to upgrade to a paid account.
 
-[![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FMoodle%2Fmaster%2Fazuredeploy.json)  [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.png)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FMoodle%2Fmaster%2Fazuredeploy.json)
+[![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FMoodle%2Fdb-sku-update%2Fazuredeploy.json)  [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.png)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FMoodle%2Fdb-sku-update%2Fazuredeploy.json)
 
 ## Stack Architecture
 

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -65,123 +65,12 @@
             },
             "type": "bool"
         },
-        "storageAccountType": {
-            "defaultValue": "Standard_LRS",
-            "allowedValues": [
-                "Standard_LRS",
-                "Standard_GRS",
-                "Standard_ZRS"
-            ],
+        "siteURL": {
+            "defaultValue": "www.example.org",
             "metadata": {
-                "description": "Storage Account type"
+                "description": "URL for Moodle site"
             },
             "type": "string"
-        },
-        "dbServerType": {
-            "defaultValue": "mysql",
-            "allowedValues": [
-                "postgres",
-                "mysql",
-                "mssql"
-            ],
-            "metadata": {
-                "description": "Database type"
-            },
-            "type": "string"
-        },
-        "fileServerType": {
-            "defaultValue": "nfs",
-            "allowedValues": [
-                "gluster",
-                "nfs"
-            ],
-            "metadata": {
-                "description": "File server type: GlusterFS, NFS--not yet highly available"
-            },
-            "type": "string"
-        },
-        "webServerType": {
-            "defaultValue": "apache",
-            "allowedValues": [
-                "apache",
-                "nginx"
-            ],
-            "metadata": {
-                "description": "Web server type"
-            },
-            "type": "string"
-        },
-        "controllerVmSku": {
-            "defaultValue": "Standard_DS1_v2",
-            "metadata": {
-                "description": "VM size for the controller node"
-            },
-            "type": "string"
-        },
-        "autoscaleVmSku": {
-            "defaultValue": "Standard_DS2_v2",
-            "metadata": {
-                "description": "VM size for autoscaled nodes"
-            },
-            "type": "string"
-        },
-        "autoscaleVmCount": {
-            "defaultValue": 10,
-            "metadata": {
-                "description": "Maximum number of autoscaled nodes"
-            },
-            "type": "int"
-        },
-        "elasticVmSku": {
-            "defaultValue": "Standard_DS2_v2",
-            "metadata": {
-                "description": "VM size for the elastic search nodes"
-            },
-            "type": "string"
-        },
-        "gatewaySubnet": {
-            "allowedValues": [
-                "GatewaySubnet"
-            ],
-            "defaultValue": "GatewaySubnet",
-            "metadata": {
-                "description": "name for Virtual network gateway subnet"
-            },
-            "type": "string"
-        },
-        "gatewayType": {
-            "allowedValues": [
-                "Vpn",
-                "ER"
-            ],
-            "defaultValue": "Vpn",
-            "metadata": {
-                "description": "Virtual network gateway type"
-            },
-            "type": "string"
-        },
-        "glusterVmSku": {
-            "defaultValue": "Standard_DS2_v2",
-            "metadata": {
-                "description": "VM size for the gluster nodes"
-            },
-            "type": "string"
-        },
-        "fileServerDiskSize": {
-            "defaultValue": 127,
-            "metadata": {
-                "description": "Size per disk for gluster nodes or nfs server"
-            },
-            "type": "int"
-        },
-        "fileServerDiskCount": {
-            "defaultValue": 4,
-            "minValue": 2,
-            "maxValue": 8,
-            "metadata": {
-                "description": "Number of disks in raid0 per gluster node or nfs server"
-            },
-            "type": "int"
         },
         "moodleVersion": {
             "allowedValues": [
@@ -198,17 +87,67 @@
             },
             "type": "string"
         },
+        "sshPublicKey": {
+            "metadata": {
+                "description": "ssh public key"
+            },
+            "type": "string"
+        },
+        "sshUsername": {
+            "defaultValue": "azureadmin",
+            "metadata": {
+                "description": "ssh user name"
+            },
+            "type": "string"
+        },
+        "controllerVmSku": {
+            "defaultValue": "Standard_DS1_v2",
+            "metadata": {
+                "description": "VM size for the controller VM"
+            },
+            "type": "string"
+        },
+        "webServerType": {
+            "defaultValue": "apache",
+            "allowedValues": [
+                "apache",
+                "nginx"
+            ],
+            "metadata": {
+                "description": "Web server type"
+            },
+            "type": "string"
+        },
+        "autoscaleVmSku": {
+            "defaultValue": "Standard_DS2_v2",
+            "metadata": {
+                "description": "VM size for autoscaled web VMs"
+            },
+            "type": "string"
+        },
+        "autoscaleVmCount": {
+            "defaultValue": 10,
+            "metadata": {
+                "description": "Maximum number of autoscaled web VMs"
+            },
+            "type": "int"
+        },
+        "dbServerType": {
+            "defaultValue": "mysql",
+            "allowedValues": [
+                "postgres",
+                "mysql",
+                "mssql"
+            ],
+            "metadata": {
+                "description": "Database type"
+            },
+            "type": "string"
+        },
         "dbLogin": {
             "defaultValue": "dbadmin",
             "metadata": {
                 "description": "Database admin username"
-            },
-            "type": "string"
-        },
-        "siteURL": {
-            "defaultValue": "www.example.org",
-            "metadata": {
-                "description": "URL for Moodle site"
             },
             "type": "string"
         },
@@ -281,6 +220,17 @@
             },
             "type": "string"
         },
+        "sslEnforcement": {
+            "allowedValues": [
+                "Disabled",
+                "Enabled"
+            ],
+            "defaultValue": "Disabled",
+            "metadata": {
+                "description": "MySql/Postgresql SSL connection"
+            },
+            "type": "string"
+        },
         "mssqlDbServiceObjectiveName": {
             "allowedValues": [
                 "S1",
@@ -346,27 +296,56 @@
             },
             "type": "string"
         },
-        "sshPublicKey": {
-            "metadata": {
-                "description": "ssh public key"
-            },
-            "type": "string"
-        },
-        "sshUsername": {
-            "defaultValue": "azureadmin",
-            "metadata": {
-                "description": "ssh user name"
-            },
-            "type": "string"
-        },
-        "sslEnforcement": {
+        "fileServerType": {
+            "defaultValue": "nfs",
             "allowedValues": [
-                "Disabled",
-                "Enabled"
+                "gluster",
+                "nfs"
             ],
-            "defaultValue": "Disabled",
             "metadata": {
-                "description": "MySql/Postgresql SSL connection"
+                "description": "File server type: GlusterFS, NFS--not yet highly available"
+            },
+            "type": "string"
+        },
+        "fileServerDiskSize": {
+            "defaultValue": 127,
+            "metadata": {
+                "description": "Size per disk for gluster nodes or nfs server"
+            },
+            "type": "int"
+        },
+        "fileServerDiskCount": {
+            "defaultValue": 4,
+            "minValue": 2,
+            "maxValue": 8,
+            "metadata": {
+                "description": "Number of disks in raid0 per gluster node or nfs server"
+            },
+            "type": "int"
+        },
+        "glusterVmSku": {
+            "defaultValue": "Standard_DS2_v2",
+            "metadata": {
+                "description": "VM size for the gluster nodes"
+            },
+            "type": "string"
+        },
+        "storageAccountType": {
+            "defaultValue": "Standard_LRS",
+            "allowedValues": [
+                "Standard_LRS",
+                "Standard_GRS",
+                "Standard_ZRS"
+            ],
+            "metadata": {
+                "description": "Storage Account type"
+            },
+            "type": "string"
+        },
+        "elasticVmSku": {
+            "defaultValue": "Standard_DS2_v2",
+            "metadata": {
+                "description": "VM size for the elastic search nodes"
             },
             "type": "string"
         },
@@ -374,6 +353,27 @@
             "defaultValue": "172.31.0.0",
             "metadata": {
                 "description": "Address range for the Moodle virtual network - presumed /16 - further subneting during vnet creation"
+            },
+            "type": "string"
+        },
+        "gatewaySubnet": {
+            "allowedValues": [
+                "GatewaySubnet"
+            ],
+            "defaultValue": "GatewaySubnet",
+            "metadata": {
+                "description": "name for Virtual network gateway subnet"
+            },
+            "type": "string"
+        },
+        "gatewayType": {
+            "allowedValues": [
+                "Vpn",
+                "ER"
+            ],
+            "defaultValue": "Vpn",
+            "metadata": {
+                "description": "Virtual network gateway type"
             },
             "type": "string"
         },

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -7,7 +7,7 @@
             "metadata": {
                 "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
             },
-            "defaultValue": "https://raw.githubusercontent.com/Azure/Moodle/master/"
+            "defaultValue": "https://raw.githubusercontent.com/Azure/Moodle/db-sku-update/"
         },
         "_artifactsLocationSasToken": {
             "type": "securestring",

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -227,6 +227,60 @@
             },
             "type": "int"
         },
+        "mysqlPgresStgSizeGB": {
+            "defaultValue": 125,
+            "minValue": 5,
+            "maxValue": 1024,
+            "metadata": {
+                "description": "MySql/Postgresql storage size in GB. Minimum 5GB, increase by 1GB, up to 1TB (1024 GB)"
+            },
+            "type": "int"
+        },
+        "mysqlPgresSkuTier": {
+            "allowedValues": [
+                "Basic",
+                "GeneralPurpose",
+                "MemoryOptimized"
+            ],
+            "defaultValue": "GeneralPurpose",
+            "metadata": {
+                "description": "MySql/Postgresql sku tier"
+            },
+            "type": "string"
+        },
+        "mysqlPgresSkuHwFamily": {
+            "allowedValues": [
+                "Gen4",
+                "Gen5"
+            ],
+            "defaultValue": "Gen4",
+            "metadata": {
+                "description": "MySql/Postgresql sku hardware family"
+            },
+            "type": "string"
+        },
+        "mysqlVersion": {
+            "allowedValues": [
+                "5.6",
+                "5.7"
+            ],
+            "defaultValue": "5.7",
+            "metadata": {
+                "description": "Mysql version"
+            },
+            "type": "string"
+        },
+        "postgresVersion": {
+            "allowedValues": [
+                "9.5",
+                "9.6"
+            ],
+            "defaultValue": "9.6",
+            "metadata": {
+                "description": "Postgresql version"
+            },
+            "type": "string"
+        },
         "mssqlDbServiceObjectiveName": {
             "allowedValues": [
                 "S1",
@@ -282,35 +336,13 @@
             },
             "type": "string"
         },
-        "mysqlPgresStgSizeGB": {
-            "defaultValue": 125,
-            "minValue": 5,
-            "maxValue": 1024,
-            "metadata": {
-                "description": "MySql/Postgresql storage size in GB. Minimum 5GB, increase by 1GB, up to 1TB (1024 GB)"
-            },
-            "type": "int"
-        },
-        "mysqlPgresSkuTier": {
+        "mssqlVersion": {
             "allowedValues": [
-                "Basic",
-                "GeneralPurpose",
-                "MemoryOptimized"
+                "12.0"
             ],
-            "defaultValue": "GeneralPurpose",
+            "defaultValue": "12.0",
             "metadata": {
-                "description": "MySql/Postgresql sku tier"
-            },
-            "type": "string"
-        },
-        "mysqlPgresSkuHwFamily": {
-            "allowedValues": [
-                "Gen4",
-                "Gen5"
-            ],
-            "defaultValue": "Gen4",
-            "metadata": {
-                "description": "MySql/Postgresql sku hardware family"
+                "description": "Mssql version"
             },
             "type": "string"
         },
@@ -335,38 +367,6 @@
             "defaultValue": "Disabled",
             "metadata": {
                 "description": "MySql/Postgresql SSL connection"
-            },
-            "type": "string"
-        },
-        "postgresVersion": {
-            "allowedValues": [
-                "9.5",
-                "9.6"
-            ],
-            "defaultValue": "9.6",
-            "metadata": {
-                "description": "Postgresql version"
-            },
-            "type": "string"
-        },
-        "mysqlVersion": {
-            "allowedValues": [
-                "5.6",
-                "5.7"
-            ],
-            "defaultValue": "5.7",
-            "metadata": {
-                "description": "Mysql version"
-            },
-            "type": "string"
-        },
-        "mssqlVersion": {
-            "allowedValues": [
-                "12.0"
-            ],
-            "defaultValue": "12.0",
-            "metadata": {
-                "description": "Mssql version"
             },
             "type": "string"
         },
@@ -711,9 +711,15 @@
             "moodleDbUserAzure": "[concat('moodle', '@', parameters('dbServerType'), '-', variables('resourceprefix'))]",
             "moodleInstallScriptFilename": "install_moodle.sh",
             "moodleVersion": "[parameters('moodleVersion')]",
+            "mssqlDbServiceObjectiveName": "[parameters('mssqlDbServiceObjectiveName')]",
             "mssqlDbSize": "[parameters('mssqlDbSize')]",
             "mssqlDbEdition": "[parameters('mssqlDbEdition')]",
             "mssqlVersion": "[parameters('mssqlVersion')]",
+            "mysqlPgresSkuHwFamily": "[parameters('mysqlPgresSkuHwFamily')]",
+            "mysqlPgresSkuName": "[concat(if(equals(parameters('mysqlPgresSkuTier'),'Basic'),'B', if(equals(parameters('mysqlPgresSkuTier'),'GeneralPurpose'),'GP', 'MO')), '_', parameters('mysqlPgresSkuHwFamily'), '_', string(parameters('mysqlPgresVcores')))]",
+            "mysqlPgresSkuTier": "[parameters('mysqlPgresSkuTier')]",
+            "mysqlPgresStgSizeGB": "[parameters('mysqlPgresStgSizeGB')]",
+            "mysqlPgresVcores": "[parameters('mysqlPgresVcores')]",
             "mysqlVersion": "[parameters('mysqlVersion')]",
             "osType": {
                 "offer": "UbuntuServer",
@@ -727,14 +733,8 @@
             "redisDeploySwitch": "[parameters('redisDeploySwitch')]",
             "redisDns": "[concat('redis-',variables('resourceprefix'),'.redis.cache.windows.net')]",
             "resourcesPrefix": "[variables('resourceprefix')]",
-            "mssqlDbServiceObjectiveName": "[parameters('mssqlDbServiceObjectiveName')]",
             "serverName": "[concat(parameters('dbServerType'), '-',variables('resourceprefix'))]",
             "siteURL": "[if(or(empty(parameters('siteURL')), equals(parameters('siteURL'), 'www.example.org')), concat('lb-',variables('resourceprefix'),'.',resourceGroup().location,'.cloudapp.azure.com'), parameters('siteURL'))]",
-            "mysqlPgresVcores": "[parameters('mysqlPgresVcores')]",
-            "mysqlPgresSkuName": "[concat(if(equals(parameters('mysqlPgresSkuTier'),'Basic'),'B', if(equals(parameters('mysqlPgresSkuTier'),'GeneralPurpose'),'GP', 'MO')), '_', parameters('mysqlPgresSkuHwFamily'), '_', string(parameters('mysqlPgresVcores')))]",
-            "mysqlPgresStgSizeGB": "[parameters('mysqlPgresStgSizeGB')]",
-            "mysqlPgresSkuTier": "[parameters('mysqlPgresSkuTier')]",
-            "mysqlPgresSkuHwFamily": "[parameters('mysqlPgresSkuHwFamily')]",
             "sshPublicKey": "[parameters('sshPublicKey')]",
             "sshUsername": "[parameters('sshUsername')]",
             "sslEnforcement": "[parameters('sslEnforcement')]",

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -162,7 +162,7 @@
             ],
             "defaultValue": 2,
             "metadata": {
-                "description": "MySql/Postgresql vCores. For Baisc tier, only 1 & 2 are allowed. For GeneralPurpose tier, 2, 4, 8, 16, 32 are allowed. For MemoryOptimized, 2, 4, 8, 16 are allowed."
+                "description": "MySql/Postgresql vCores. For Basic tier, only 1 & 2 are allowed. For GeneralPurpose tier, 2, 4, 8, 16, 32 are allowed. For MemoryOptimized, 2, 4, 8, 16 are allowed."
             },
             "type": "int"
         },
@@ -244,7 +244,7 @@
             ],
             "defaultValue": "S1",
             "metadata": {
-                "description": "MS SQL database service object names. There are a lot more than S* (to be added later). See https://docs.microsoft.com/en-us/rest/api/sql/databases/createorupdate#ServiceObjectiveName"
+                "description": "MS SQL database service object names"
             },
             "type": "string"
         },
@@ -282,7 +282,7 @@
             ],
             "defaultValue": "Standard",
             "metadata": {
-                "description": "MS SQL DB edition. There are a lot more than Basic & Standard (to be added later). See https://docs.microsoft.com/en-us/rest/api/sql/databases/createorupdate#DatabaseEdition"
+                "description": "MS SQL DB edition"
             },
             "type": "string"
         },

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -7,7 +7,7 @@
             "metadata": {
                 "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
             },
-            "defaultValue": "https://raw.githubusercontent.com/Azure/Moodle/db-sku-update/"
+            "defaultValue": "https://raw.githubusercontent.com/Azure/Moodle/master/"
         },
         "_artifactsLocationSasToken": {
             "type": "securestring",

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -212,22 +212,22 @@
             },
             "type": "string"
         },
-        "skuCapacityDTU": {
+        "mysqlPgresVcores": {
             "allowedValues": [
-                50,
-                100,
-                200,
-                400,
-                800
+                1,
+                2,
+                4,
+                8,
+                16,
+                32
             ],
-            "defaultValue": 100,
+            "defaultValue": 2,
             "metadata": {
-                "description": "MySql/Postgresql database trasaction units"
+                "description": "MySql/Postgresql vCores. For Baisc tier, only 1 & 2 are allowed. For GeneralPurpose tier, 2, 4, 8, 16, 32 are allowed. For MemoryOptimized, 2, 4, 8, 16 are allowed."
             },
             "type": "int"
         },
-
-        "serviceObjective": {
+        "mssqlDbServiceObjectiveName": {
             "allowedValues": [
                 "S1",
                 "S2",
@@ -240,11 +240,11 @@
             ],
             "defaultValue": "S1",
             "metadata": {
-                "description": "MS SQL  database trasaction units"
+                "description": "MS SQL database service object names. There are a lot more than S* (to be added later). See https://docs.microsoft.com/en-us/rest/api/sql/databases/createorupdate#ServiceObjectiveName"
             },
             "type": "string"
         },
-        "msDbSize": {
+        "mssqlDbSize": {
             "allowedValues": [
                 "100MB",
                 "250MB",
@@ -271,42 +271,46 @@
             },
             "type": "string"
         },
-        "skuName": {
-            "allowedValues": [
-                "PGSQLB50",
-                "PGSQLB100",
-                "PGSQLS100",
-                "PGSQLS200",
-                "PGSQLS400",
-                "PGSQLS800",
-                "MYSQLB50",
-                "MYSQLB100",
-                "MYSQLS100",
-                "MYSQLS200",
-                "MYSQLS400",
-                "MYSQLS800"
-            ],
-            "defaultValue": "MYSQLS100",
-            "metadata": {
-                "description": "MySql/Postgresql sku name"
-            },
-            "type": "string"
-        },
-        "skuSizeMB": {
-            "defaultValue": 128000,
-            "metadata": {
-                "description": "MySql/Postgresql sku size in MB. For Basic tier, minimum 50GB, increased by 125GB up to 1TB. For Standard tier, minimum 125GB, increase by 125GB up to 1TB"
-            },
-            "type": "int"
-        },
-        "skuTier": {
+        "mssqlDbEdition": {
             "allowedValues": [
                 "Basic",
                 "Standard"
             ],
             "defaultValue": "Standard",
             "metadata": {
+                "description": "MS SQL DB edition. There are a lot more than Basic & Standard (to be added later). See https://docs.microsoft.com/en-us/rest/api/sql/databases/createorupdate#DatabaseEdition"
+            },
+            "type": "string"
+        },
+        "mysqlPgresStgSizeGB": {
+            "defaultValue": 125,
+            "minValue": 5,
+            "maxValue": 1024,
+            "metadata": {
+                "description": "MySql/Postgresql storage size in GB. Minimum 5GB, increase by 1GB, up to 1TB (1024 GB)"
+            },
+            "type": "int"
+        },
+        "mysqlPgresSkuTier": {
+            "allowedValues": [
+                "Basic",
+                "GeneralPurpose",
+                "MemoryOptimized"
+            ],
+            "defaultValue": "GeneralPurpose",
+            "metadata": {
                 "description": "MySql/Postgresql sku tier"
+            },
+            "type": "string"
+        },
+        "mysqlPgresSkuHwFamily": {
+            "allowedValues": [
+                "Gen4",
+                "Gen5"
+            ],
+            "defaultValue": "Gen4",
+            "metadata": {
+                "description": "MySql/Postgresql sku hardware family"
             },
             "type": "string"
         },
@@ -707,7 +711,8 @@
             "moodleDbUserAzure": "[concat('moodle', '@', parameters('dbServerType'), '-', variables('resourceprefix'))]",
             "moodleInstallScriptFilename": "install_moodle.sh",
             "moodleVersion": "[parameters('moodleVersion')]",
-            "msDbSize": "[parameters('msDbSize')]",
+            "mssqlDbSize": "[parameters('mssqlDbSize')]",
+            "mssqlDbEdition": "[parameters('mssqlDbEdition')]",
             "mssqlVersion": "[parameters('mssqlVersion')]",
             "mysqlVersion": "[parameters('mysqlVersion')]",
             "osType": {
@@ -722,13 +727,14 @@
             "redisDeploySwitch": "[parameters('redisDeploySwitch')]",
             "redisDns": "[concat('redis-',variables('resourceprefix'),'.redis.cache.windows.net')]",
             "resourcesPrefix": "[variables('resourceprefix')]",
-            "serviceObjective": "[parameters('serviceObjective')]",
+            "mssqlDbServiceObjectiveName": "[parameters('mssqlDbServiceObjectiveName')]",
             "serverName": "[concat(parameters('dbServerType'), '-',variables('resourceprefix'))]",
             "siteURL": "[if(or(empty(parameters('siteURL')), equals(parameters('siteURL'), 'www.example.org')), concat('lb-',variables('resourceprefix'),'.',resourceGroup().location,'.cloudapp.azure.com'), parameters('siteURL'))]",
-            "skuCapacityDTU": "[parameters('skuCapacityDTU')]",
-            "skuName": "[parameters('skuName')]",
-            "skuSizeMB": "[parameters('skuSizeMB')]",
-            "skuTier": "[parameters('skuTier')]",
+            "mysqlPgresVcores": "[parameters('mysqlPgresVcores')]",
+            "mysqlPgresSkuName": "[concat(if(equals(parameters('mysqlPgresSkuTier'),'Basic'),'B', if(equals(parameters('mysqlPgresSkuTier'),'GeneralPurpose'),'GP', 'MO')), '_', parameters('mysqlPgresSkuHwFamily'), '_', string(parameters('mysqlPgresVcores')))]",
+            "mysqlPgresStgSizeGB": "[parameters('mysqlPgresStgSizeGB')]",
+            "mysqlPgresSkuTier": "[parameters('mysqlPgresSkuTier')]",
+            "mysqlPgresSkuHwFamily": "[parameters('mysqlPgresSkuHwFamily')]",
             "sshPublicKey": "[parameters('sshPublicKey')]",
             "sshUsername": "[parameters('sshUsername')]",
             "sslEnforcement": "[parameters('sslEnforcement')]",

--- a/azuredeploy.parameters.json
+++ b/azuredeploy.parameters.json
@@ -17,13 +17,12 @@
                 "mysqlVersion":                { "value": "5.7" },
                 "postgresVersion":             { "value": "9.6" },
                 "siteURL":                     { "value": "www.example.org" },
-                "skuCapacityDTU":              { "value": 50 },
-                "skuName":                     { "value": "MYSQLB50" },
-                "skuSizeMB":                   { "value": 51200 },
-                "skuTier":                     { "value": "Basic" },
+                "mysqlPgresVcores":            { "value": 1 },
+                "mysqlPgresStgSizeGB":         { "value": 5 },
+                "mysqlPgresSkuTier":           { "value": "Basic" },
                 "vNetAddressSpace":            { "value": "172.31.0.0" },
                 "sshPublicKey":                { "value": "GEN-SSH-PUB-KEY" },
-                "serviceObjective":            { "value": "S7" },
-                "msDbSize":                    { "value": "250GB" }
+                "mssqlDbServiceObjectiveName": { "value": "S7" },
+                "mssqlDbSize":                 { "value": "250GB" }
         }
 }

--- a/docs/Deploy.md
+++ b/docs/Deploy.md
@@ -115,13 +115,14 @@ together.
 
 ### Database Sizing
 
-As of the time of this writing, Azure supports "Basic" and "Standard"
-tiers for database instances. In addition the skuCapacityDTU defines
-Compute Units, and the number of those you can use is limited by
+As of the time of this writing, Azure supports "Basic", "General Purpose" and "Memory Optimized"
+tiers for MySQL/PostgreSQL database instances. In addition the mysqlPgresVcores defines
+the number of vCores for each DB server instance, and the number of those you can use is limited by
 database tier:
 
-- Basic: 50, 100
-- Standard: 100, 200, 400, 800
+- Basic: 1, 2
+- General Purpose: 2, 4, 8, 16, 32
+- Memory Optimized: 2, 4, 8, 16
 
 This value also limits the maximum number of connections, as defined
 here: https://docs.microsoft.com/en-us/azure/mysql/concepts-limits
@@ -129,14 +130,13 @@ here: https://docs.microsoft.com/en-us/azure/mysql/concepts-limits
 As the Moodle database will handle cron processes as well as the
 website, any public facing website with more than 10 users will likely
 require upgrading to 100. Once the site reaches 30+ users it will
-require upgrading to Standard for more compute units. This depends
+require upgrading to General Purpose for more compute units. This depends
 entirely on the individual site. As MySQL databases cannot change (or
 be restored to a different tier) once deployed it is a good idea to
 slightly overspec your database.
 
-Standard instances have a minimum storage requirement of 128000MB. All
-database storage, regardless of tier, has a hard upper limit of 1
-terrabyte. After 128GB you gain additional iops for each GB, so if
+All MySQL/PostgreSQL database storage, regardless of tier, has a hard upper limit of 1
+terabyte (1024 GB), starting from 5 GB minimum, increasing by 1 GB. You gain additional iops for each added GB, so if
 you're expecting a heavy amount of traffic you will want to oversize
 your storage. The current maximum iops with a 1TB disk is 3000.
 

--- a/docs/Parameters.md
+++ b/docs/Parameters.md
@@ -42,7 +42,7 @@ Type: securestring
 
 Possible Values: null
 
-Default:
+Default: 
 
 
 ### applyScriptsSwitch
@@ -56,6 +56,28 @@ Possible Values: null
 Default: true
 
 
+### autoscaleVmCount
+
+Maximum number of autoscaled web VMs
+
+Type: int
+
+Possible Values: null
+
+Default: 10
+
+
+### autoscaleVmSku
+
+VM size for autoscaled web VMs
+
+Type: string
+
+Possible Values: null
+
+Default: Standard_DS2_v2
+
+
 ### azureBackupSwitch
 
 Switch to configure AzureBackup and enlist VM's
@@ -67,59 +89,26 @@ Possible Values: null
 Default: false
 
 
-### redisDeploySwitch
+### controllerVmSku
 
-Switch to deploy a redis cache or not
-
-Type: bool
-
-Possible Values: null
-
-Default: true
-
-
-### vnetGwDeploySwitch
-
-Switch to deploy a virtual network gateway or not
-
-Type: bool
-
-Possible Values: null
-
-Default: false
-
-
-### installO365pluginsSwitch
-
-Switch to install Moodle Office 365 plugins
-
-Type: bool
-
-Possible Values: null
-
-Default: false
-
-
-### installElasticSearchSwitch
-
-Switch to install Moodle ElasticSearch plugins & VMs
-
-Type: bool
-
-Possible Values: null
-
-Default: false
-
-
-### storageAccountType
-
-Storage Account type
+VM size for the controller VM
 
 Type: string
 
-Possible Values: ["Standard_LRS","Standard_GRS","Standard_ZRS"]
+Possible Values: null
 
-Default: Standard_LRS
+Default: Standard_DS1_v2
+
+
+### dbLogin
+
+Database admin username
+
+Type: string
+
+Possible Values: null
+
+Default: dbadmin
 
 
 ### dbServerType
@@ -133,61 +122,6 @@ Possible Values: ["postgres","mysql","mssql"]
 Default: mysql
 
 
-### fileServerType
-
-File server type: GlusterFS, Azure Files (CIFS)--disabled due to too slow perf, NFS--not highly available
-
-Type: string
-
-Possible Values: ["gluster","nfs"]
-
-Default: gluster
-
-
-### webServerType
-
-Web server type
-
-Type: string
-
-Possible Values: ["apache","nginx"]
-
-Default: apache
-
-
-### controllerVmSku
-
-VM size for the controller node
-
-Type: string
-
-Possible Values: null
-
-Default: Standard_DS1_v2
-
-
-### autoscaleVmSku
-
-VM size for autoscaled nodes
-
-Type: string
-
-Possible Values: null
-
-Default: Standard_DS2_v2
-
-
-### autoscaleVmCount
-
-Maximum number of autoscaled nodes
-
-Type: int
-
-Possible Values: null
-
-Default: 10
-
-
 ### elasticVmSku
 
 VM size for the elastic search nodes
@@ -197,6 +131,39 @@ Type: string
 Possible Values: null
 
 Default: Standard_DS2_v2
+
+
+### fileServerDiskCount
+
+Number of disks in raid0 per gluster node or nfs server
+
+Type: int
+
+Possible Values: null
+
+Default: 4
+
+
+### fileServerDiskSize
+
+Size per disk for gluster nodes or nfs server
+
+Type: int
+
+Possible Values: null
+
+Default: 127
+
+
+### fileServerType
+
+File server type: GlusterFS, NFS--not yet highly available
+
+Type: string
+
+Possible Values: ["gluster","nfs"]
+
+Default: nfs
 
 
 ### gatewaySubnet
@@ -232,26 +199,37 @@ Possible Values: null
 Default: Standard_DS2_v2
 
 
-### fileServerDiskSize
+### htmlLocalCopySwitch
 
-Size per disk for gluster nodes or nfs server
+Switch to create a local copy of /moodle/html or not
 
-Type: int
-
-Possible Values: null
-
-Default: 127
-
-
-### fileServerDiskCount
-
-Number of disks in raid0 per gluster node or nfs server
-
-Type: int
+Type: bool
 
 Possible Values: null
 
-Default: 4
+Default: false
+
+
+### installElasticSearchSwitch
+
+Switch to install Moodle ElasticSearch plugins & VMs
+
+Type: bool
+
+Possible Values: null
+
+Default: false
+
+
+### installO365pluginsSwitch
+
+Switch to install Moodle Office 365 plugins
+
+Type: bool
+
+Possible Values: null
+
+Default: false
 
 
 ### moodleVersion
@@ -265,42 +243,20 @@ Possible Values: ["MOODLE_34_STABLE","MOODLE_33_STABLE","MOODLE_32_STABLE","MOOD
 Default: MOODLE_34_STABLE
 
 
-### dbLogin
+### mssqlDbEdition
 
-Database admin username
-
-Type: string
-
-Possible Values: null
-
-Default: dbadmin
-
-
-### siteURL
-
-URL for Moodle site
+MS SQL DB edition
 
 Type: string
 
-Possible Values: null
+Possible Values: ["Basic","Standard"]
 
-Default: www.example.org
-
-
-### mysqlPgresVcores
-
-MySql/Postgresql database trasaction units
-
-Type: int
-
-Possible Values: [1,2,4,8,16,32]
-
-Default: 2
+Default: Standard
 
 
 ### mssqlDbServiceObjectiveName
 
-MS SQL database service object names. There are a lot more than S* (to be added later).
+MS SQL database service object names
 
 Type: string
 
@@ -320,26 +276,26 @@ Possible Values: ["100MB","250MB","500MB","1GB","2GB","5GB","10GB","20GB","30GB"
 Default: 250GB
 
 
-### mssqlDbEdition
+### mssqlVersion
 
-MS SQL DB edition
+Mssql version
 
 Type: string
 
-Possible Values: ["Basic","Standard"]
+Possible Values: ["12.0"]
 
-Default: Standard
+Default: 12.0
 
 
-### mysqlPgresStgSizeGB
+### mysqlPgresSkuHwFamily
 
-MySql/Postgresql sku size in MB. For Basic tier, minimum 50GB, increased by 125GB up to 1TB. For Standard tier, minimum 125GB, increase by 125GB up to 1TB
+MySql/Postgresql sku hardware family
 
-Type: int
+Type: string
 
-Possible Values: null
+Possible Values: ["Gen4","Gen5"]
 
-Default: 128000
+Default: Gen4
 
 
 ### mysqlPgresSkuTier
@@ -350,7 +306,73 @@ Type: string
 
 Possible Values: ["Basic","GeneralPurpose","MemoryOptimized"]
 
-Default: Standard
+Default: GeneralPurpose
+
+
+### mysqlPgresStgSizeGB
+
+MySql/Postgresql storage size in GB. Minimum 5GB, increase by 1GB, up to 1TB (1024 GB)
+
+Type: int
+
+Possible Values: null
+
+Default: 125
+
+
+### mysqlPgresVcores
+
+MySql/Postgresql vCores. For Basic tier, only 1 & 2 are allowed. For GeneralPurpose tier, 2, 4, 8, 16, 32 are allowed. For MemoryOptimized, 2, 4, 8, 16 are allowed.
+
+Type: int
+
+Possible Values: [1,2,4,8,16,32]
+
+Default: 2
+
+
+### mysqlVersion
+
+Mysql version
+
+Type: string
+
+Possible Values: ["5.6","5.7"]
+
+Default: 5.7
+
+
+### postgresVersion
+
+Postgresql version
+
+Type: string
+
+Possible Values: ["9.5","9.6"]
+
+Default: 9.6
+
+
+### redisDeploySwitch
+
+Switch to deploy a redis cache or not
+
+Type: bool
+
+Possible Values: null
+
+Default: true
+
+
+### siteURL
+
+URL for Moodle site
+
+Type: string
+
+Possible Values: null
+
+Default: www.example.org
 
 
 ### sshPublicKey
@@ -386,37 +408,15 @@ Possible Values: ["Disabled","Enabled"]
 Default: Disabled
 
 
-### postgresVersion
+### storageAccountType
 
-Postgresql version
-
-Type: string
-
-Possible Values: ["9.5","9.6"]
-
-Default: 9.6
-
-
-### mysqlVersion
-
-Mysql version
+Storage Account type
 
 Type: string
 
-Possible Values: ["5.6","5.7"]
+Possible Values: ["Standard_LRS","Standard_GRS","Standard_ZRS"]
 
-Default: 5.7
-
-
-### mssqlVersion
-
-Mssql version
-
-Type: string
-
-Possible Values: ["12.0"]
-
-Default: 12.0
+Default: Standard_LRS
 
 
 ### vNetAddressSpace
@@ -430,6 +430,17 @@ Possible Values: null
 Default: 172.31.0.0
 
 
+### vnetGwDeploySwitch
+
+Switch to deploy a virtual network gateway or not
+
+Type: bool
+
+Possible Values: null
+
+Default: false
+
+
 ### vpnType
 
 Virtual network gateway vpn type
@@ -439,4 +450,16 @@ Type: string
 Possible Values: ["RouteBased","PolicyBased"]
 
 Default: RouteBased
+
+
+### webServerType
+
+Web server type
+
+Type: string
+
+Possible Values: ["apache","nginx"]
+
+Default: apache
+
 

--- a/docs/Parameters.md
+++ b/docs/Parameters.md
@@ -287,20 +287,20 @@ Possible Values: null
 Default: www.example.org
 
 
-### skuCapacityDTU
+### mysqlPgresVcores
 
 MySql/Postgresql database trasaction units
 
 Type: int
 
-Possible Values: [50,100,200,400,800]
+Possible Values: [1,2,4,8,16,32]
 
-Default: 100
+Default: 2
 
 
-### serviceObjective
+### mssqlDbServiceObjectiveName
 
-MS SQL  database trasaction units
+MS SQL database service object names. There are a lot more than S* (to be added later).
 
 Type: string
 
@@ -309,7 +309,7 @@ Possible Values: ["S1","S2","S3","S4","S5","S6","S7","S9"]
 Default: S1
 
 
-### msDbSize
+### mssqlDbSize
 
 MS SQL database size
 
@@ -320,18 +320,18 @@ Possible Values: ["100MB","250MB","500MB","1GB","2GB","5GB","10GB","20GB","30GB"
 Default: 250GB
 
 
-### skuName
+### mssqlDbEdition
 
-MySql/Postgresql sku name
+MS SQL DB edition
 
 Type: string
 
-Possible Values: ["PGSQLB50","PGSQLB100","PGSQLS100","PGSQLS200","PGSQLS400","PGSQLS800","MYSQLB50","MYSQLB100","MYSQLS100","MYSQLS200","MYSQLS400","MYSQLS800"]
+Possible Values: ["Basic","Standard"]
 
-Default: MYSQLS100
+Default: Standard
 
 
-### skuSizeMB
+### mysqlPgresStgSizeGB
 
 MySql/Postgresql sku size in MB. For Basic tier, minimum 50GB, increased by 125GB up to 1TB. For Standard tier, minimum 125GB, increase by 125GB up to 1TB
 
@@ -342,13 +342,13 @@ Possible Values: null
 Default: 128000
 
 
-### skuTier
+### mysqlPgresSkuTier
 
 MySql/Postgresql sku tier
 
 Type: string
 
-Possible Values: ["Basic","Standard"]
+Possible Values: ["Basic","GeneralPurpose","MemoryOptimized"]
 
 Default: Standard
 

--- a/loadtest/azuredeploy.parameters.loadtest.defaults.json
+++ b/loadtest/azuredeploy.parameters.loadtest.defaults.json
@@ -4,9 +4,8 @@
     "parameters": {
         "autoscaleVmSku":              { "value": "__WEB_VM_SKU__" },
         "dbServerType":                { "value": "__DB_SERVER_TYPE__" },
-        "skuCapacityDTU":              { "value": 100 },
-        "skuName":                     { "value": "__DB_SKU_NAME__" },
-        "skuSizeMB":                   { "value": 128 },
+        "mysqlPgresVcores":            { "value": 2 },
+        "mysqlPgresStgSizeGB":         { "value": 125 },
         "webServerType":               { "value": "__WEB_SERVER_TYPE__" },
         "fileServerType":              { "value": "__FILE_SERVER_TYPE__" },
         "fileServerDiskCount":         { "value": 2 },

--- a/loadtest/loadtest.sh
+++ b/loadtest/loadtest.sh
@@ -117,7 +117,7 @@ function deploy_moodle_with_some_parameters
     eval $cmd || return 1
 
     local deployment_name="${resource_group}-deployment"
-    local cmd="az group deployment create --resource-group $resource_group --name $deployment_name $no_wait_flag --template-uri $template_url --parameters @$parameters_template_file webServerType=$web_server_type autoscaleVmSku=$web_vm_sku dbServerType=$db_server_type skuCapacityDTU=$db_dtu skuName=$db_sku_name skuSizeMB=$db_size_mb fileServerType=$file_server_type fileServerDiskCount=$file_server_disk_count fileServerDiskSize=$file_server_disk_size redisDeploySwitch=$redis_cache sshPublicKey='$ssh_pub_key'"
+    local cmd="az group deployment create --resource-group $resource_group --name $deployment_name $no_wait_flag --template-uri $template_url --parameters @$parameters_template_file webServerType=$web_server_type autoscaleVmSku=$web_vm_sku dbServerType=$db_server_type mysqlPgresVcores=$db_dtu mysqlPgresSkuName=$db_sku_name mysqlPgresStgSizeGB=$db_size_mb fileServerType=$file_server_type fileServerDiskCount=$file_server_disk_count fileServerDiskSize=$file_server_disk_size redisDeploySwitch=$redis_cache sshPublicKey='$ssh_pub_key'"
     show_command_to_run $cmd
     eval $cmd
 }

--- a/nested/controllerconfig.json
+++ b/nested/controllerconfig.json
@@ -31,7 +31,7 @@
                     ]
                 },
                 "protectedSettings":{
-                    "commandToExecute": "[concat('bash ', parameters('moodleCommon').moodleInstallScriptFilename, ' ', parameters('moodleCommon').moodleVersion, ' ', concat(parameters('moodleCommon').gfsNameRoot, '0'), ' ', 'data', ' ', parameters('moodleCommon').siteURL, ' ', parameters('moodleCommon').dbDNS, ' ', parameters('moodleCommon').moodleDbName, ' ', parameters('moodleCommon').moodleDbUser, ' ', parameters('moodleCommon').moodleDbPass, ' ', parameters('moodleCommon').moodleAdminPass, ' ', concat(parameters('moodleCommon').dbLogin, '@', parameters('moodleCommon').dbServerType, '-', parameters('moodleCommon').resourcesPrefix), ' ', parameters('moodleCommon').dbLoginPassword, ' ', parameters('moodleCommon').storageAccountName, ' ', listKeys(variables('storageAccountId'), '2017-06-01').keys[0].value, ' ', parameters('moodleCommon').moodleDbUserAzure, ' ', parameters('moodleCommon').redisDns, ' ', parameters('redisKey'), ' ', parameters('moodleCommon').elasticVm1IP, ' ', parameters('moodleCommon').installO365pluginsSwitch, ' ', parameters('moodleCommon').installElasticSearchSwitch, ' ', parameters('moodleCommon').dbServerType, ' ', parameters('moodleCommon').fileServerType , ' ', parameters('moodleCommon').serviceObjective, ' ',  parameters('moodleCommon').skuTier, ' ',  parameters('moodleCommon').msDbSize )]"
+                    "commandToExecute": "[concat('bash ', parameters('moodleCommon').moodleInstallScriptFilename, ' ', parameters('moodleCommon').moodleVersion, ' ', concat(parameters('moodleCommon').gfsNameRoot, '0'), ' ', 'data', ' ', parameters('moodleCommon').siteURL, ' ', parameters('moodleCommon').dbDNS, ' ', parameters('moodleCommon').moodleDbName, ' ', parameters('moodleCommon').moodleDbUser, ' ', parameters('moodleCommon').moodleDbPass, ' ', parameters('moodleCommon').moodleAdminPass, ' ', concat(parameters('moodleCommon').dbLogin, '@', parameters('moodleCommon').dbServerType, '-', parameters('moodleCommon').resourcesPrefix), ' ', parameters('moodleCommon').dbLoginPassword, ' ', parameters('moodleCommon').storageAccountName, ' ', listKeys(variables('storageAccountId'), '2017-06-01').keys[0].value, ' ', parameters('moodleCommon').moodleDbUserAzure, ' ', parameters('moodleCommon').redisDns, ' ', parameters('redisKey'), ' ', parameters('moodleCommon').elasticVm1IP, ' ', parameters('moodleCommon').installO365pluginsSwitch, ' ', parameters('moodleCommon').installElasticSearchSwitch, ' ', parameters('moodleCommon').dbServerType, ' ', parameters('moodleCommon').fileServerType , ' ', parameters('moodleCommon').mssqlDbServiceObjectiveName, ' ',  parameters('moodleCommon').mssqlDbEdition, ' ',  parameters('moodleCommon').mssqlDbSize )]"
                 },
                 "type": "CustomScript",
                 "typeHandlerVersion": "2.0"
@@ -54,9 +54,9 @@
         "documentation10": "    moodleDbUser                - database user for moodle",
         "documentation11": "    moodleDbPass                - database password for moodleDbUser",
         "documentation12": "    moodleAdminPass             - password for moodle admin user",
-        "documentation13": "    serviceObjective            - MS SQL porformance tier.",
-        "documentation14": "    skuTier                     - MS SQL edition tier",
-        "documentation15": "    msDbSize                    - MS SQL database size",
+        "documentation13": "    mssqlDbServiceObjectiveName - MS SQL porformance tier.",
+        "documentation14": "    mssqlDbEdition              - MS SQL edition tier",
+        "documentation15": "    mssqlDbSize                 - MS SQL database size",
 
         "scriptUri": "[concat(parameters('moodleCommon').scriptLocation,parameters('moodleCommon').moodleInstallScriptFilename,parameters('moodleCommon').artifactsSasToken)]",
         "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('moodleCommon').storageAccountName)]"

--- a/nested/mssql.json
+++ b/nested/mssql.json
@@ -31,7 +31,6 @@
             "properties": {
                 "administratorLogin": "[parameters('moodleCommon').dbLogin]",
                 "administratorLoginPassword": "[parameters('moodleCommon').dbLoginPassword]",
-                "storageMB": "[parameters('moodleCommon').skuSizeMB]",
                 "version": "[parameters('moodleCommon').mssqlVersion]"
             },
             "resources": [
@@ -70,10 +69,6 @@
         "documentation11": " mssqlVersion               - Mssql version",
         "documentation2": " administratorLogin          - Mssql admin username",
         "documentation3": " administratorLoginPassword  - Mssql admin password",
-        "documentation4": " location                    - Mssql server location",
-        "documentation5": " skuCapacityDTU              - Mssql database trasaction units",
-        "documentation7": " skuName                     - Mssql sku name",
-        "documentation8": " skuSizeMB                   - Mssql sku size in mb",
-        "documentation9": " skuTier                     - Mssql sku tier"
+        "documentation4": " location                    - Mssql server location"
     }
 }

--- a/nested/mysql.json
+++ b/nested/mysql.json
@@ -24,7 +24,7 @@
     "resources": [
         {
             "type": "Microsoft.DBforMySQL/servers",
-            "apiVersion": "2017-04-30-preview",
+            "apiVersion": "2017-12-01",
             "kind": "",
             "location": "[resourceGroup().location]",
             "name": "[parameters('moodleCommon').serverName]",
@@ -32,12 +32,23 @@
                 "administratorLogin": "[parameters('moodleCommon').dbLogin]",
                 "administratorLoginPassword": "[parameters('moodleCommon').dbLoginPassword]",
                 "sslEnforcement": "[parameters('moodleCommon').sslEnforcement]",
-                "storageMB": "[parameters('moodleCommon').skuSizeMB]",
+                "storageProfile": {
+                    "storageMB": "[mul(parameters('moodleCommon').mysqlPgresStgSizeGB, 1024)]",
+                    "backupRetentionDays": "35",
+                    "geoRedundantBackup": "Enabled"
+                },
                 "version": "[parameters('moodleCommon').mysqlVersion]"
+            },
+            "sku": {
+                "capacity": "[parameters('moodleCommon').mysqlPgresVcores]",
+                "name": "[parameters('moodleCommon').mysqlPgresSkuName]",
+                "size": "[parameters('moodleCommon').mysqlPgresStgSizeGB]",
+                "tier": "[parameters('moodleCommon').mysqlPgresSkuTier]",
+                "family": "[parameters('moodleCommon').mysqlPgresSkuHwFamily]"
             },
             "resources": [
                 {
-                    "apiVersion": "2017-04-30-preview",
+                    "apiVersion": "2017-12-01",
                     "dependsOn": [
                         "[concat('Microsoft.DBforMySQL/servers/', parameters('moodleCommon').serverName)]"
                     ],
@@ -50,7 +61,7 @@
                     "type": "firewallRules"
                 },
                 {
-                    "apiVersion": "2017-04-30-preview",
+                    "apiVersion": "2017-12-01",
                     "dependsOn": [
                         "[concat('Microsoft.DBforMySQL/servers/', parameters('moodleCommon').serverName)]"
                     ],
@@ -62,13 +73,7 @@
                     },
                     "type": "firewallRules"
                 }
-            ],
-            "sku": {
-                "capacity": "[parameters('moodleCommon').skuCapacityDTU]",
-                "name": "[parameters('moodleCommon').skuName]",
-                "size": "[parameters('moodleCommon').skuSizeMB]",
-                "tier": "[parameters('moodleCommon').skuTier]"
-            }
+            ]
         }
     ],
     "variables": {
@@ -78,9 +83,10 @@
         "documentation2": " administratorLogin          - mysql admin username",
         "documentation3": " administratorLoginPassword  - mysql admin password",
         "documentation4": " location                    - Mysql server location",
-        "documentation5": " skuCapacityDTU              - Mysql database trasaction units",
-        "documentation7": " skuName                     - Mysql sku name",
-        "documentation8": " skuSizeMB                   - Mysql sku size in mb",
-        "documentation9": " skuTier                     - Mysql sku tier"
+        "documentation5": " mysqlPgresVcores            - Mysql database trasaction units",
+        "documentation7": " mysqlPgresSkuName           - Mysql sku name",
+        "documentation8": " mysqlPgresStgSizeGB         - Mysql sku size in mb",
+        "documentation9": " mysqlPgresSkuTier           - Mysql sku tier",
+        "documentationA": " mysqlPgresSkuHwFamily       - Mysql sku hardware family"
     }
 }

--- a/nested/postgres.json
+++ b/nested/postgres.json
@@ -24,7 +24,7 @@
     "resources": [
         {
             "type": "Microsoft.DBforPostgreSQL/servers",
-            "apiVersion": "2017-04-30-preview",
+            "apiVersion": "2017-12-01",
             "kind": "",
             "location": "[resourceGroup().location]",
             "name": "[parameters('moodleCommon').serverName]",
@@ -32,12 +32,23 @@
                 "administratorLogin": "[parameters('moodleCommon').dbLogin]",
                 "administratorLoginPassword": "[parameters('moodleCommon').dbLoginPassword]",
                 "sslEnforcement": "[parameters('moodleCommon').sslEnforcement]",
-                "storageMB": "[parameters('moodleCommon').skuSizeMB]",
+                "storageProfile": {
+                    "storageMB": "[mul(parameters('moodleCommon').mysqlPgresStgSizeGB, 1024)]",
+                    "backupRetentionDays": "35",
+                    "geoRedundantBackup": "Enabled"
+                },
                 "version": "[parameters('moodleCommon').postgresVersion]"
+            },
+            "sku": {
+                "capacity": "[parameters('moodleCommon').mysqlPgresVcores]",
+                "name": "[parameters('moodleCommon').mysqlPgresSkuName]",
+                "size": "[parameters('moodleCommon').mysqlPgresStgSizeGB]",
+                "tier": "[parameters('moodleCommon').mysqlPgresSkuTier]",
+                "family": "[parameters('moodleCommon').mysqlPgresSkuHwFamily]"
             },
             "resources": [
                 {
-                    "apiVersion": "2017-04-30-preview",
+                    "apiVersion": "2017-12-01",
                     "dependsOn": [
                         "[concat('Microsoft.DBforPostgreSQL/servers/', parameters('moodleCommon').serverName)]"
                     ],
@@ -50,7 +61,7 @@
                     "type": "firewallRules"
                 },
                 {
-                    "apiVersion": "2017-04-30-preview",
+                    "apiVersion": "2017-12-01",
                     "dependsOn": [
                         "[concat('Microsoft.DBforPostgreSQL/servers/', parameters('moodleCommon').serverName)]"
                     ],
@@ -62,13 +73,7 @@
                     },
                     "type": "firewallRules"
                 }
-            ],
-            "sku": {
-                "capacity": "[parameters('moodleCommon').skuCapacityDTU]",
-                "name": "[parameters('moodleCommon').skuName]",
-                "size": "[parameters('moodleCommon').skuSizeMB]",
-                "tier": "[parameters('moodleCommon').skuTier]"
-            }
+            ]
         }
     ],
     "variables": {
@@ -78,9 +83,10 @@
         "documentation2": " administratorLogin          - postgresql admin username",
         "documentation3": " administratorLoginPassword  - postgresql admin password",
         "documentation4": " location                    - Postgresql server location",
-        "documentation5": " skuCapacityDTU              - Postgresql database trasaction units",
-        "documentation7": " skuName                     - Postgresql sku name",
-        "documentation8": " skuSizeMB                  - Postgresql sku size in mb",
-        "documentation9": " skuTier                    - Postgresql sku tier"
+        "documentation5": " mysqlPgresVcores            - Postgresql database trasaction units",
+        "documentation7": " mysqlPgresSkuName           - Postgresql sku name",
+        "documentation8": " mysqlPgresStgSizeGB         - Postgresql sku size in mb",
+        "documentation9": " mysqlPgresSkuTier           - Postgresql sku tier",
+        "documentationA": " mysqlPgresSkuHwFamily       - Mysql sku hardware family"
     }
 }

--- a/scripts/install_moodle.sh
+++ b/scripts/install_moodle.sh
@@ -43,9 +43,9 @@
     installElasticSearchSwitch=${19}
     dbServerType=${20}
     fileServerType=${21}
-    serviceObjective=${22}
-    serviceTier=${23}
-    serviceSize=${24}
+    mssqlDbServiceObjectiveName=${22}
+    mssqlDbEdition=${23}
+    mssqlDbSize=${24}
 
 
     echo $moodleVersion        >> /tmp/vars.txt
@@ -69,9 +69,9 @@
     echo $installElasticSearchSwitch  >> /tmp/vars.txt
     echo $dbServerType                >> /tmp/vars.txt
     echo $fileServerType              >> /tmp/vars.txt
-    echo $serviceObjective	>> /tmp/vars.txt
-    echo $serviceTier	>> /tmp/vars.txt
-    echo $serviceSize	>> /tmp/vars.txt
+    echo $mssqlDbServiceObjectiveName >> /tmp/vars.txt
+    echo $mssqlDbEdition	>> /tmp/vars.txt
+    echo $mssqlDbSize	>> /tmp/vars.txt
 
     . ./helper_functions.sh
     check_fileServerType_param $fileServerType
@@ -1170,7 +1170,7 @@ EOF
         echo "mysql -h $mysqlIP -u $mysqladminlogin -p${mysqladminpass} -e \"CREATE DATABASE ${moodledbname};\"" >> /tmp/debug
         echo "mysql -h $mysqlIP -u $mysqladminlogin -p${mysqladminpass} -e \"GRANT ALL ON ${moodledbname}.* TO ${moodledbuser} IDENTIFIED BY '${moodledbpass}';\"" >> /tmp/debug
     elif [ $dbServerType = "mssql" ]; then
-        /opt/mssql-tools/bin/sqlcmd -S $mssqlIP -U $mssqladminlogin -P ${mssqladminpass} -Q "CREATE DATABASE ${moodledbname} ( MAXSIZE = $serviceSize, EDITION = '$serviceTier', SERVICE_OBJECTIVE = '$serviceObjective' )"
+        /opt/mssql-tools/bin/sqlcmd -S $mssqlIP -U $mssqladminlogin -P ${mssqladminpass} -Q "CREATE DATABASE ${moodledbname} ( MAXSIZE = $mssqlDbSize, EDITION = '$mssqlDbEdition', SERVICE_OBJECTIVE = '$mssqlDbServiceObjectiveName' )"
         /opt/mssql-tools/bin/sqlcmd -S $mssqlIP -U $mssqladminlogin -P ${mssqladminpass} -Q "CREATE LOGIN ${moodledbuser} with password = '${moodledbpass}'" 
         /opt/mssql-tools/bin/sqlcmd -S $mssqlIP -U $mssqladminlogin -P ${mssqladminpass} -d ${moodledbname} -Q "CREATE USER ${moodledbuser} FROM LOGIN ${moodledbuser}"
         /opt/mssql-tools/bin/sqlcmd -S $mssqlIP -U $mssqladminlogin -P ${mssqladminpass} -d ${moodledbname} -Q "exec sp_addrolemember 'db_owner','${moodledbuser}'" 


### PR DESCRIPTION
Fixes #53 and #28 

This change should alleviate confusion in configuring DB. I also rearranged the template params for better grouping. You'll see params are ordered as follows:

- Switches
- Moodle params, controller configs (ssh)
- Web VMSS configs
- DB configs: MySQL/PostgreSQL first, followed by MS SQL
- File server configs
- Misc: Elastic search VM SKU, networking, storage account type
