### PR TITLE
Add Azure Application Gateway option (fixes #31)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ node_modules
 
 # Eclipse
 .project
+
+# Specific azuredeploy.parameters.json files for dev testing (ignored not to expose ssh pub keys)
+.params/

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -400,6 +400,40 @@
             },
             "type": "string"
         },
+        "appGwSkuName": {
+            "defaultValue": "Standard_Medium",
+            "allowedValues": [
+                "Standard_Small",
+                "Standard_Medium",
+                "Standard_Large",
+                "WAF_Medium",
+                "WAF_Large"
+            ],
+            "metadata": {
+                "description": "(App Gateway https termination only) Name of the Applicate Gateway SKU"
+            },
+            "type": "string"
+        },
+        "appGwSkuTier": {
+            "defaultValue": "Standard",
+            "allowedValues": [
+                "Standard",
+                "WAF"
+            ],
+            "metadata": {
+                "description": "(App Gateway https termination only) Tier of the Applicate Gateway"
+            },
+            "type": "string"
+        },
+        "appGwSkuCapacity": {
+            "defaultValue": 2,
+            "maxValue": 10,
+            "minValue": 2,
+            "metadata": {
+                "description": "(App Gateway https termination only) Capacity instance count) of the Applicate Gateway"
+            },
+            "type": "int"
+        },
         "storageAccountType": {
             "defaultValue": "Standard_LRS",
             "allowedValues": [
@@ -828,6 +862,9 @@
             "appGwPipName": "[concat('appgw-pubip-',variables('resourceprefix'))]",
             "appGwSslCertKeyVaultResourceId": "[parameters('appGwSslCertKeyVaultResourceId')]",
             "appGwSslCertKeyVaultSecretName": "[parameters('appGwSslCertKeyVaultSecretName')]",
+            "appGwSkuCapacity": "[parameters('appGwSkuCapacity')]",
+            "appGwSkuName": "[parameters('appGwSkuName')]",
+            "appGwSkuTier": "[parameters('appGwSkuTier')]",
             "applyScriptsSwitch": "[parameters('applyScriptsSwitch')]",
             "autoscaleVmCount": "[parameters('autoscaleVmCount')]",
             "autoscaleVmSku": "[parameters('autoscaleVmSku')]",

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -825,6 +825,7 @@
 
             "appGwBePoolName": "[concat('appgw-bepool-', variables('resourceprefix'))]",
             "appGwName": "[concat('appgw-', variables('resourceprefix'))]",
+            "appGwPipName": "[concat('appgw-pubip-',variables('resourceprefix'))]",
             "appGwSslCertKeyVaultResourceId": "[parameters('appGwSslCertKeyVaultResourceId')]",
             "appGwSslCertKeyVaultSecretName": "[parameters('appGwSslCertKeyVaultSecretName')]",
             "applyScriptsSwitch": "[parameters('applyScriptsSwitch')]",

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -921,7 +921,7 @@
             "resourcesPrefix": "[variables('resourceprefix')]",
             "searchType": "[parameters('searchType')]",
             "serverName": "[concat(parameters('dbServerType'), '-',variables('resourceprefix'))]",
-            "siteURL": "[if(or(empty(parameters('siteURL')), equals(parameters('siteURL'), 'www.example.org')), concat('lb-',variables('resourceprefix'),'.',resourceGroup().location,'.cloudapp.azure.com'), parameters('siteURL'))]",
+            "siteURL": "[if(or(empty(parameters('siteURL')), equals(parameters('siteURL'), 'www.example.org')), concat(if(equals(parameters('httpsTermination'), 'AppGw'),'appgw-','lb-'),variables('resourceprefix'),'.',resourceGroup().location,'.cloudapp.azure.com'), parameters('siteURL'))]",
             "sshPublicKey": "[parameters('sshPublicKey')]",
             "sshUsername": "[parameters('sshUsername')]",
             "sslEnforcement": "[parameters('sslEnforcement')]",

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -75,11 +75,12 @@
         "httpsTermination": {
             "allowedValues": [
                 "VMSS",
+                "AppGw",
                 "None"
             ],
             "defaultValue": "VMSS",
             "metadata": {
-                "description": "Indicates where https termination occurs. 'VMSS' is for https termination at the VMSS instance VMs (using nginx https proxy). 'None' is for testing only with no https. 'None' may not be used with a separately configured https termination layer. If you want to use the 'None' option with your separately configured https termination layer, you'll need to update your Moodle config.php manually for $cfg->wwwroot and $cfg->sslproxy."
+                "description": "Indicates where https termination occurs. 'VMSS' is for https termination at the VMSS instance VMs (using nginx https proxy). 'AppGw' is for https termination with an Azure Application Gateway. When selecting this, you need to specify all appGw* parameters. 'None' is for testing only with no https. 'None' may not be used with a separately configured https termination layer. If you want to use the 'None' option with your separately configured https termination layer, you'll need to update your Moodle config.php manually for $cfg->wwwroot and $cfg->sslproxy."
             },
             "type": "string"
         },
@@ -353,35 +354,49 @@
         "keyVaultResourceId": {
             "defaultValue": "",
             "metadata": {
-                "description": "Azure Resource Manager resource ID of the Key Vault in case you stored your SSL cert in an Azure Key Vault (Note that this Key Vault must have been pre-created on the same Azure region where this template is being deployed). Leave this blank if you didn't. Resource ID example: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/xxx/providers/Microsoft.KeyVault/vaults/yyy. This value can be obtained from keyvault.sh output if you used the script to store your SSL cert in your Key Vault."
+                "description": "(VMSS https termination only) Azure Resource Manager resource ID of the Key Vault in case you stored your SSL cert in an Azure Key Vault (Note that this Key Vault must have been pre-created on the same Azure region where this template is being deployed). Leave this blank if you didn't. Resource ID example: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/xxx/providers/Microsoft.KeyVault/vaults/yyy. This value can be obtained from keyvault.sh output if you used the script to store your SSL cert in your Key Vault."
             },
             "type": "string"
         },
         "sslCertKeyVaultURL": {
             "defaultValue": "",
             "metadata": {
-                "description": "Azure Key Vault URL for your stored SSL cert. This value can be obtained from keyvault.sh output if you used the script to store your SSL cert in your Key Vault. This parameter is ignored if the keyVaultResourceId parameter is blank."
+                "description": "(VMSS https termination only) Azure Key Vault URL for your stored SSL cert. This value can be obtained from keyvault.sh output if you used the script to store your SSL cert in your Key Vault. This parameter is ignored if the keyVaultResourceId parameter is blank."
             },
             "type": "string"
         },
         "sslCertThumbprint": {
             "defaultValue": "",
             "metadata": {
-                "description": "Thumbprint of your stored SSL cert. This value can be obtained from keyvault.sh output if you used the script to store your SSL cert in your Key Vault. This parameter is ignored if the keyVaultResourceId parameter is blank."
+                "description": "(VMSS https termination only) Thumbprint of your stored SSL cert. This value can be obtained from keyvault.sh output if you used the script to store your SSL cert in your Key Vault. This parameter is ignored if the keyVaultResourceId parameter is blank."
             },
             "type": "string"
         },
         "caCertKeyVaultURL": {
             "defaultValue": "",
             "metadata": {
-                "description": "Azure Key Vault URL for your stored CA (Certificate Authority) cert. This value can be obtained from keyvault.sh output if you used the script to store your CA cert in your Key Vault. This parameter is ignored if the keyVaultResourceId parameter is blank."
+                "description": "(VMSS https termination only) Azure Key Vault URL for your stored CA (Certificate Authority) cert. This value can be obtained from keyvault.sh output if you used the script to store your CA cert in your Key Vault. This parameter is ignored if the keyVaultResourceId parameter is blank."
             },
             "type": "string"
         },
         "caCertThumbprint": {
             "defaultValue": "",
             "metadata": {
-                "description": "Thumbprint of your stored CA cert. This value can be obtained from keyvault.sh output if you used the script to store your CA cert in your Key Vault. This parameter is ignored if the keyVaultResourceId parameter is blank."
+                "description": "(VMSS https termination only) Thumbprint of your stored CA cert. This value can be obtained from keyvault.sh output if you used the script to store your CA cert in your Key Vault. This parameter is ignored if the keyVaultResourceId parameter is blank."
+            },
+            "type": "string"
+        },
+        "appGwSslCertKeyVaultResourceId": {
+            "defaultValue": "",
+            "metadata": {
+                "description": "(App Gateway https termination only) Azure Key Vault URL for your stored SSL cert, again for App Gateway https termination case only. (Note that this Key Vault must have been pre-created on the same Azure region where this template is being deployed). Leave this blank if you didn't. Resource ID example: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/xxx/providers/Microsoft.KeyVault/vaults/yyy."
+            },
+            "type": "string"
+        },
+        "appGwSslCertKeyVaultSecretName": {
+            "defaultValue": "",
+            "metadata": {
+                "description": "(App Gateway https termination only) Name of the Azure Key Vault secret that's stored in the previously specified Key Vault as a PFX certificate (with no password) for your site's SSL cert. This secret must be pre-populated in the specified Key Vault with the matching name."
             },
             "type": "string"
         },
@@ -808,6 +823,10 @@
             "scriptLocation": "[concat(parameters('_artifactsLocation'), 'scripts/')]",
             "artifactsSasToken": "[parameters('_artifactsLocationSasToken')]",
 
+            "appGwBePoolName": "[concat('appgw-bepool-', variables('resourceprefix'))]",
+            "appGwName": "[concat('appgw-', variables('resourceprefix'))]",
+            "appGwSslCertKeyVaultResourceId": "[parameters('appGwSslCertKeyVaultResourceId')]",
+            "appGwSslCertKeyVaultSecretName": "[parameters('appGwSslCertKeyVaultSecretName')]",
             "applyScriptsSwitch": "[parameters('applyScriptsSwitch')]",
             "autoscaleVmCount": "[parameters('autoscaleVmCount')]",
             "autoscaleVmSku": "[parameters('autoscaleVmSku')]",
@@ -907,6 +926,9 @@
             "sslEnforcement": "[parameters('sslEnforcement')]",
             "storageAccountName": "[tolower(concat('abs',variables('resourceprefix')))]",
             "storageAccountType": "[parameters('storageAccountType')]",
+            "subnetAppGw": "[concat('appgw-subnet-',variables('resourceprefix'))]",
+            "subnetAppGwPrefix": "[concat(variables('octets')[0], '.', variables('octets')[1], '.', string(add(int(variables('octets')[2]),6)))]",
+            "subnetAppGwRange": "[concat(variables('octets')[0], '.', variables('octets')[1], '.', string(add(int(variables('octets')[2]),6)), '.0/24')]",
             "subnetElastic": "[concat('elastic-subnet-',variables('resourceprefix'))]",
             "subnetElasticPrefix": "[concat( variables('octets')[0], '.', variables('octets')[1], '.', string(add(int(variables('octets')[2]),4)))]",
             "subnetElasticRange": "[concat( variables('octets')[0], '.', variables('octets')[1], '.', string(add(int(variables('octets')[2]),4)), '.0/24')]",

--- a/nested/appgw.json
+++ b/nested/appgw.json
@@ -120,7 +120,7 @@
         "virtualNetworkName": "[parameters('moodleCommon').vnetName]",
         "virtualNetworkID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
         "appGwBePoolName": "[parameters('moodleCommon').appGwBePoolName]",
-        "appGwPublicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('moodleCommon').lbPipName)]",
+        "appGwPublicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('moodleCommon').appGwPipName)]",
         "appGwSubnetName": "[parameters('moodleCommon').subnetAppGw]",
         "appGwSubnetID": "[concat(variables('virtualNetworkID'),'/subnets/',variables('appGwSubnetName'))]",
         "appGwName": "[parameters('moodleCommon').appGwName]",

--- a/nested/appgw.json
+++ b/nested/appgw.json
@@ -23,9 +23,9 @@
             "apiVersion": "2018-02-01",
             "properties": {
                 "sku": {
-                    "name": "Standard_Medium",
-                    "tier": "Standard",
-                    "capacity": "2"
+                    "name": "[parameters('moodleCommon').appGwSkuName]",
+                    "tier": "[parameters('moodleCommon').appGwSkuTier]",
+                    "capacity": "[parameters('moodleCommon').appGwSkuCapacity]"
                 },
                 "gatewayIPConfigurations": [
                     {

--- a/nested/appgw.json
+++ b/nested/appgw.json
@@ -1,0 +1,129 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "moodleCommon": {
+            "metadata": {
+                "description": "Common Moodle values"
+            },
+            "type": "object"
+        },
+        "sslCertData": {
+            "metadata": {
+                "description": "Base64-encoded PFX (no password protected) file content for the SSL cert to be used on the App Gateway for SSL termination. Should be passed from an Azure Key Vault."
+            },
+            "type": "securestring"
+        }
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Network/applicationGateways",
+            "name": "[parameters('moodleCommon').appGwName]",
+            "location": "[resourceGroup().location]",
+            "apiVersion": "2018-02-01",
+            "properties": {
+                "sku": {
+                    "name": "Standard_Medium",
+                    "tier": "Standard",
+                    "capacity": "2"
+                },
+                "gatewayIPConfigurations": [
+                    {
+                        "name": "appGwIpConfig",
+                        "properties": {
+                            "subnet": {
+                                "id": "[variables('appGwSubnetID')]"
+                            }
+                        }
+                    }
+                ],
+                "frontendIPConfigurations": [
+                    {
+                        "name": "appGwFrontendIP",
+                        "properties": {
+                            "publicIPAddress": {
+                                "id": "[variables('appGwPublicIPAddressID')]"
+                            }
+                        }
+                    }
+                ],
+                "frontendPorts": [
+                    {
+                        "name": "appGwFrontendPort",
+                        "properties": {
+                            "port": 443
+                        }
+                    }
+                ],
+                "backendAddressPools": [
+                    {
+                        "name": "[variables('appGwBePoolName')]"
+                    }
+                ],
+                "backendHttpSettingsCollection": [
+                    {
+                        "name": "appGwBackendHttpSettings",
+                        "properties": {
+                            "port": 80,
+                            "protocol": "Http",
+                            "cookieBasedAffinity": "Disabled"
+                        }
+                    }
+                ],
+                "sslCertificates": [
+                    {
+                        "name": "appGatewaySslCert",
+                        "properties": {
+                            "data": "[parameters('sslCertData')]"
+                        }
+                    }
+                ],
+                "httpListeners": [
+                    {
+                        "name": "appGwHttpListener",
+                        "properties": {
+                            "frontendIPConfiguration": {
+                                "Id": "[concat(variables('appGwID'), '/frontendIPConfigurations/appGwFrontendIP')]"
+                            },
+                            "frontendPort": {
+                                "Id": "[concat(variables('appGwID'), '/frontendPorts/appGwFrontendPort')]"
+                            },
+                            "protocol": "Https",
+                            "sslCertificate": {
+                                "Id": "[concat(variables('appGwID'), '/sslCertificates/appGatewaySslCert')]"
+                            }
+                        }
+                    }
+                ],
+                "requestRoutingRules": [
+                    {
+                        "Name": "rule1",
+                        "properties": {
+                            "ruleType": "Basic",
+                            "httpListener": {
+                                "id": "[concat(variables('appGwID'), '/httpListeners/appGwHttpListener')]"
+                            },
+                            "backendAddressPool": {
+                                "id": "[concat(variables('appGwID'), '/backendAddressPools/', variables('appGwBePoolName'))]"
+                            },
+                            "backendHttpSettings": {
+                                "id": "[concat(variables('appGwID'), '/backendHttpSettingsCollection/appGwBackendHttpSettings')]"
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    ],
+    "variables": {
+        "documentation1": "This sub-template creates an Azure Application Gateway for SSL offloading. It expects certain values in the 'common' datastructure.",
+        "virtualNetworkName": "[parameters('moodleCommon').vnetName]",
+        "virtualNetworkID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+        "appGwBePoolName": "[parameters('moodleCommon').appGwBePoolName]",
+        "appGwPublicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('moodleCommon').lbPipName)]",
+        "appGwSubnetName": "[parameters('moodleCommon').subnetAppGw]",
+        "appGwSubnetID": "[concat(variables('virtualNetworkID'),'/subnets/',variables('appGwSubnetName'))]",
+        "appGwName": "[parameters('moodleCommon').appGwName]",
+        "appGwID": "[resourceId('Microsoft.Network/applicationGateways',variables('appGwName'))]"
+    }
+}

--- a/nested/network.json
+++ b/nested/network.json
@@ -57,6 +57,12 @@
                         "properties": {
                             "addressPrefix": "[parameters('moodleCommon').gatewaySubnetRange]"
                         }
+                    },
+                    {
+                        "name": "[parameters('moodleCommon').subnetAppGw]",
+                        "properties": {
+                            "addressPrefix": "[parameters('moodleCommon').subnetAppGwRange]"
+                        }
                     }
                 ]
             }
@@ -153,6 +159,7 @@
             }
         },
         {
+            "condition": "[not(equals(parameters('moodleCommon').httpsTermination, 'AppGw'))]",
             "type": "Microsoft.Network/loadBalancers",
             "apiVersion": "2017-10-01",
             "dependsOn": [
@@ -227,6 +234,35 @@
                         }
                     }
                 ]
+            }
+        },
+        {
+            "condition": "[equals(parameters('moodleCommon').httpsTermination, 'AppGw')]",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2017-05-10",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/virtualNetworks', parameters('moodleCommon').vnetName)]",
+                "[concat('Microsoft.Network/publicIPAddresses/',parameters('moodleCommon').lbPipName)]"
+            ],
+            "name": "appGwTemplate",
+            "properties": {
+                "mode": "Incremental",
+                "parameters": {
+                    "moodleCommon": {
+                        "value": "[parameters('moodleCommon')]"
+                    },
+                    "sslCertData": {
+                        "reference": {
+                            "keyVault": {
+                                "id": "[parameters('moodleCommon').appGwSslCertKeyVaultResourceId]"
+                            },
+                            "secretName": "[parameters('moodleCommon').appGwSslCertKeyVaultSecretName]"
+                        }
+                    }
+                },
+                "templateLink": {
+                    "uri": "[concat(parameters('moodleCommon').baseTemplateUrl,'appgw.json',parameters('moodleCommon').artifactsSasToken)]"
+                }
             }
         }
     ],

--- a/nested/network.json
+++ b/nested/network.json
@@ -129,6 +129,7 @@
             }
         },
         {
+            "condition": "[not(equals(parameters('moodleCommon').httpsTermination, 'AppGw'))]",
             "type": "Microsoft.Network/publicIPAddresses",
             "apiVersion": "2017-10-01",
             "location": "[resourceGroup().location]",
@@ -141,6 +142,22 @@
             },
             "tags": {
                 "displayName": "Load Balancer Public IP"
+            }
+        },
+        {
+            "condition": "[equals(parameters('moodleCommon').httpsTermination, 'AppGw')]",
+            "type": "Microsoft.Network/publicIPAddresses",
+            "apiVersion": "2017-10-01",
+            "location": "[resourceGroup().location]",
+            "name": "[parameters('moodleCommon').appGwPipName]",
+            "properties": {
+                "dnsSettings": {
+                    "domainNameLabel": "[parameters('moodleCommon').appGwName]"
+                },
+                "publicIPAllocationMethod": "Dynamic"
+            },
+            "tags": {
+                "displayName": "App Gateway Public IP (must be dynamic)"
             }
         },
         {
@@ -290,7 +307,7 @@
     },
     "outputs": {
         "lbPubIp": {
-            "value": "[reference(parameters('moodleCommon').lbPipName, '2017-10-01').ipAddress]",
+            "value": "[if(equals(parameters('moodleCommon').httpsTermination, 'AppGw'), '0.0.0.0', reference(parameters('moodleCommon').lbPipName, '2017-10-01').ipAddress)]",
             "type": "string"
         },
         "ctlrPubIp": {

--- a/nested/webvmss.json
+++ b/nested/webvmss.json
@@ -65,11 +65,8 @@
                                         {
                                             "name": "ipcfg_lb",
                                             "properties": {
-                                                "loadBalancerBackendAddressPools": [
-                                                    {
-                                                        "id": "[variables('extBeID')]"
-                                                    }
-                                                ],
+                                                "loadBalancerBackendAddressPools": "[take(variables('lbBePoolArray'), variables('lbBePoolArrayTakeCount'))]",
+                                                "applicationGatewayBackendAddressPools": "[take(variables('appGwBePoolArray'), variables('appGwBePoolArrayTakeCount'))]",
                                                 "subnet": {
                                                     "id": "[variables('subnetWebRef')]"
                                                 }
@@ -193,7 +190,23 @@
         "subnetWebRef": "[concat(resourceId('Microsoft.Network/virtualNetworks',parameters('moodleCommon').vnetName),'/subnets/',parameters('moodleCommon').subnetWeb)]",
         "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('moodleCommon').storageAccountName)]",
         "vmssID": "[resourceId('Microsoft.Compute/virtualMachineScaleSets',parameters('moodleCommon').vmssName)]",
-        "webvmss1NIC": "[concat('Microsoft.Compute/virtualMachineScaleSets/', parameters('moodleCommon').vmssName, '/virtualMachines/0/networkInterfaces/vmssnic')]"
+        "webvmss1NIC": "[concat('Microsoft.Compute/virtualMachineScaleSets/', parameters('moodleCommon').vmssName, '/virtualMachines/0/networkInterfaces/vmssnic')]",
+        "appGwName": "[parameters('moodleCommon').appGwName]",
+        "appGwID": "[resourceId('Microsoft.Network/applicationGateways',variables('appGwName'))]",
+        "appGwBePoolName": "[parameters('moodleCommon').appGwBePoolName]",
+        "appGwBePoolId": "[concat(variables('appGwID'), '/backendAddressPools/', variables('appGwBePoolName'))]",
+        "lbBePoolArray": [
+            {
+                "id": "[variables('extBeID')]"
+            }
+        ],
+        "lbBePoolArrayTakeCount": "[if(equals(parameters('moodleCommon').httpsTermination, 'AppGw'), 0, 1)]",
+        "appGwBePoolArray": [
+            {
+                "id": "[variables('appGwBePoolId')]"
+            }
+        ],
+        "appGwBePoolArrayTakeCount": "[if(equals(parameters('moodleCommon').httpsTermination, 'AppGw'), 1, 0)]"
     },
     "outputs": {
         "webvm1IP": {


### PR DESCRIPTION
Confirmed working. Note that because Azure App Gateway currently doesn't support statically assigned public IPs, the DB firewall rules have to be loosened a bit (to allow access from any Azure IPs). Fixes #31.