### PR TITLE
Load modified sysctl settings and tune DRBD resync speed

### DIFF
--- a/scripts/setup_nfs_ha.sh
+++ b/scripts/setup_nfs_ha.sh
@@ -96,6 +96,14 @@ resource $drbd_resource_name {
     device      ${drbd_device_path};
     disk        /dev/${vgname}/${lvname};
     meta-disk   internal;
+    disk {
+        c-fill-target 1M;
+        c-max-rate 110M;
+        c-min-rate 120K;
+    }
+    net {
+        max-buffers 20k;
+    }
     on ${node1name} {
         address ${node1ip}:7789;
     }

--- a/scripts/setup_nfs_ha.sh
+++ b/scripts/setup_nfs_ha.sh
@@ -37,6 +37,8 @@ function setup_required_packages
 options lockd nlm_udpport=2004 nlm_tcpport=2004
 options nfs callback_tcpport=2005
 EOF
+    # Reread modified sysctl settings for modified NFS ports
+    sysctl --system
 
     # We need to install the "azure-lb" command separately if the resource-agents package didn't have it.
     pushd /usr/lib/ocf/resource.d/heartbeat
@@ -236,7 +238,3 @@ NFS_EXPORT_PATH=${DRBD_MOUNT_POINT}/moodle  # TODO Allow different export dir na
 setup_corosync_and_pacemaker_for_nfs $NODE1IP $NODE2IP $DRBD_RESOURCE_NAME $DRBD_DEVICE_PATH $DRBD_MOUNT_POINT $NFS_EXPORT_PATH "$NFS_CLIENTS_IP_RANGE"
 
 echo "NFS-HA setup succeeded. NFS_EXPORT_PATH=${NFS_EXPORT_PATH}, NFS_CLIENT_SPEC=${NFS_CLIENT_SPEC}"
-
-# TODO The persistent NFS port assignments don't work until rebooted for unknown reasons. Fix this later.
-echo "Restarting the machine in 1 minute to work around the persistent NFS port assignments problem..."
-shutdown -r +1


### PR DESCRIPTION
The two commits in this branch:
  * Fix the need to reboot for static port assignments
  * Increase the performance of DRBD's resyncs
