### PR TITLE
Add highly available NFS option

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -362,10 +362,11 @@
             "defaultValue": "nfs",
             "allowedValues": [
                 "gluster",
-                "nfs"
+                "nfs",
+                "nfs-ha"
             ],
             "metadata": {
-                "description": "File server type: GlusterFS, NFS--not yet highly available"
+                "description": "File server type: GlusterFS, NFS, and NFS-HA (2-VM highly available NFS cluster)"
             },
             "type": "string"
         },
@@ -385,10 +386,10 @@
             },
             "type": "int"
         },
-        "glusterVmSku": {
+        "fileServerVmSku": {
             "defaultValue": "Standard_DS2_v2",
             "metadata": {
-                "description": "VM size for the gluster nodes"
+                "description": "VM size for the gluster or NFS-HA nodes"
             },
             "type": "string"
         },
@@ -812,6 +813,75 @@
             }
         },
         {
+            "condition": "[equals(parameters('fileServerType'),'nfs-ha')]",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2017-05-10",
+            "dependsOn": [
+                "Microsoft.Resources/deployments/networkTemplate",
+                "Microsoft.Resources/deployments/recoveryTemplate"
+            ],
+            "name": "nfsHaTemplate",
+            "properties": {
+                "mode": "Incremental",
+                "parameters": {
+                    "_artifactsLocation": {
+                        "value": "[parameters('_artifactsLocation')]"
+                    },
+                    "_artifactsLocationSasToken": {
+                        "value": "[parameters('_artifactsLocationSasToken')]"
+                    },
+                    "location": {
+                        "value": "[parameters('location')]"
+                    },
+                    "subnetId": {
+                        "value": "[reference('networkTemplate').outputs.subnetIdSan.value]"
+                    },
+                    "node0IPAddr": {
+                        "value": "[variables('moodleCommon').nfsHaNode0IP]"
+                    },
+                    "node1IPAddr": {
+                        "value": "[variables('moodleCommon').nfsHaNode1IP]"
+                    },
+                    "nfsClientsIPRange": {
+                        "value": "[variables('moodleCommon').nfsHaClientsIPRange]"
+                    },
+                    "lbFrontEndIpAddr": {
+                        "value": "[variables('moodleCommon').nfsHaLbIP]"
+                    },
+                    "enableAccelNwSwitch": {
+                        "value": "[parameters('enableAccelNwForOtherVmsSwitch')]"
+                    },
+                    "vmSku": {
+                        "value": "[variables('moodleCommon').fileServerVmSku]"
+                    },
+                    "adminUserName": {
+                        "value": "[parameters('sshUsername')]"
+                    },
+                    "sshPublicKey": {
+                        "value": "[parameters('sshPublicKey')]"
+                    },
+                    "osType": {
+                        "value": "[variables('moodleCommon').osType]"
+                    },
+                    "osDiskStorageType": {
+                        "value": "[parameters('osDiskStorageType')]"
+                    },
+                    "dataDiskCountPerVM": {
+                        "value": "[parameters('fileServerDiskCount')]"
+                    },
+                    "dataDiskSizeInGB": {
+                        "value": "[parameters('fileServerDiskSize')]"
+                    },
+                    "resourcesUniqueString": {
+                        "value": "[variables('resourceprefix')]"
+                    }
+                },
+                "templateLink": {
+                    "uri": "[concat(variables('moodleCommon').baseTemplateUrl, 'nfs-ha.json', parameters('_artifactsLocationSasToken'))]"
+                }
+            }
+        },
+        {
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2017-05-10",
             "dependsOn": [
@@ -852,6 +922,7 @@
             "dependsOn": [
                 "Microsoft.Resources/deployments/vmSetupParamsTemplate",
                 "Microsoft.Resources/deployments/glusterTemplate",
+                "Microsoft.Resources/deployments/nfsHaTemplate",
                 "Microsoft.Resources/deployments/recoveryTemplate",
                 "Microsoft.Resources/deployments/networkTemplate",
                 "Microsoft.Resources/deployments/dbTemplate",
@@ -995,6 +1066,11 @@
             "commonFunctionsScriptUri": "[concat(parameters('_artifactsLocation'),'scripts/helper_functions.sh',parameters('_artifactsLocationSasToken'))]",
             "controllerVmSku": "[parameters('controllerVmSku')]",
             "customVnetId": "[parameters('customVnetId')]",
+            "ctlrNicName": "[concat('controller-vm-nic-',variables('resourceprefix'))]",
+            "ctlrNsgName": "[concat('controller-nsg-',variables('resourceprefix'))]",
+            "ctlrPipName": "[concat('controller-pubip-',variables('resourceprefix'))]",
+            "ctlrVmName": "[concat('controller-vm-',variables('resourceprefix'))]",
+            "ctlrVmSecrets": "[take(variables('ctlrVmSecretsArray'), if(empty(parameters('keyVaultResourceId')), 0, 1))]",
             "dbLogin": "[parameters('dbLogin')]",
             "dbLoginPassword": "[concat(substring(uniqueString(resourceGroup().id, deployment().name), 2, 11), '*7', toUpper('pfiwb'))]",
             "dbServerType": "[parameters('dbServerType')]",
@@ -1025,24 +1101,19 @@
             "fileServerDiskCount": "[parameters('fileServerDiskCount')]",
             "fileServerDiskSize": "[parameters('fileServerDiskSize')]",
             "fileServerType": "[parameters('fileServerType')]",
+            "fileServerVmCount": 2,
+            "fileServerVmSku": "[parameters('fileServerVmSku')]",
             "gatewayName": "[concat('vnet-gateway-',variables('resourceprefix'))]",
             "gatewayPublicIPName": "[concat('vnet-gw-ip-',variables('resourceprefix'))]",
             "gatewayType": "[parameters('gatewayType')]",
             "gfsNameRoot": "[concat('gluster-vm-',variables('resourceprefix'))]",
             "gfxAvailabilitySetName": "[concat('gluster-avset-',variables('resourceprefix'))]",
             "glusterScriptFilename": "install_gluster.sh",
-            "glusterVmCount": 2,
-            "glusterVmSku": "[parameters('glusterVmSku')]",
             "htmlLocalCopySwitch": "[parameters('htmlLocalCopySwitch')]",
             "httpsTermination": "[parameters('httpsTermination')]",
             "installGdprPluginsSwitch": "[parameters('installGdprPluginsSwitch')]",
             "installO365pluginsSwitch": "[parameters('installO365pluginsSwitch')]",
             "installObjectFsSwitch": "[parameters('installObjectFsSwitch')]",
-            "ctlrNicName": "[concat('controller-vm-nic-',variables('resourceprefix'))]",
-            "ctlrNsgName": "[concat('controller-nsg-',variables('resourceprefix'))]",
-            "ctlrPipName": "[concat('controller-pubip-',variables('resourceprefix'))]",
-            "ctlrVmName": "[concat('controller-vm-',variables('resourceprefix'))]",
-            "ctlrVmSecrets": "[take(variables('ctlrVmSecretsArray'), if(empty(parameters('keyVaultResourceId')), 0, 1))]",
             "lbDns": "[concat('lb-',variables('resourceprefix'),'.',parameters('location'),'.cloudapp.azure.com')]",
             "lbSku": "[parameters('loadBalancerSku')]",
             "lbName": "[concat('lb-',variables('resourceprefix'))]",
@@ -1066,6 +1137,11 @@
             "mysqlPgresStgSizeGB": "[parameters('mysqlPgresStgSizeGB')]",
             "mysqlPgresVcores": "[parameters('mysqlPgresVcores')]",
             "mysqlVersion": "[parameters('mysqlVersion')]",
+            "nfsHaClientsIPRange": "[variables('subnetWebRange')]",
+            "nfsHaExportPath": "/drbd/data",
+            "nfsHaLbIP": "[concat(variables('subnetSanPrefix'), '.100')]",
+            "nfsHaNode0IP": "[concat(variables('subnetSanPrefix'), '.110')]",
+            "nfsHaNode1IP": "[concat(variables('subnetSanPrefix'), '.120')]",
             "osDiskStorageType": "[parameters('osDiskStorageType')]",
             "osType": {
                 "offer": "UbuntuServer",
@@ -1100,14 +1176,14 @@
             "subnetRedisPrefix": "[concat( variables('octets')[0], '.', variables('octets')[1], '.', string(add(int(variables('octets')[2]),3)))]",
             "subnetRedisRange": "[concat( variables('octets')[0], '.', variables('octets')[1], '.', string(add(int(variables('octets')[2]),3)), '.0/24')]",
             "subnetSan": "[concat('san-subnet-',variables('resourceprefix'))]",
-            "subnetSanPrefix": "[concat( variables('octets')[0], '.', variables('octets')[1], '.', string(add(int(variables('octets')[2]),2)))]",
+            "subnetSanPrefix": "[variables('subnetSanPrefix')]",
             "subnetSanRange": "[concat( variables('octets')[0], '.', variables('octets')[1], '.', string(add(int(variables('octets')[2]),2)), '.0/24')]",
             "subnetTika": "[concat('tika-subnet-',variables('resourceprefix'))]",
             "subnetTikaPrefix": "[concat( variables('octets')[0], '.', variables('octets')[1], '.', string(add(int(variables('octets')[2]),1)))]",
             "subnetTikaRange": "[concat( variables('octets')[0], '.', variables('octets')[1], '.', string(add(int(variables('octets')[2]),1)), '.0/24')]",
             "subnetWeb": "[concat('web-subnet-',variables('resourceprefix'))]",
             "subnetWebPrefix": "[concat( variables('octets')[0], '.', variables('octets')[1], '.', string(add(int(variables('octets')[2]),0)))]",
-            "subnetWebRange": "[concat( variables('octets')[0], '.', variables('octets')[1], '.', string(add(int(variables('octets')[2]),0)), '.0/24')]",
+            "subnetWebRange": "[variables('subnetWebRange')]",
             "thumbprintSslCert": "[if(or(empty(parameters('keyVaultResourceId')), empty(parameters('sslCertThumbprint'))), 'None', parameters('sslCertThumbprint'))]",
             "thumbprintCaCert": "[if(or(empty(parameters('keyVaultResourceId')), empty(parameters('caCertThumbprint'))), 'None', parameters('caCertThumbprint'))]",
             "tikaNicName": "[concat('tika-vm-nic-',variables('resourceprefix'))]",
@@ -1143,6 +1219,8 @@
             }
         ],
         "octets": "[split(parameters('vNetAddressSpace'), '.')]",
-        "resourceprefix": "[substring(uniqueString(resourceGroup().id, deployment().name), 3, 6)]"
+        "resourceprefix": "[substring(uniqueString(resourceGroup().id, deployment().name), 3, 6)]",
+        "subnetSanPrefix": "[concat( variables('octets')[0], '.', variables('octets')[1], '.', string(add(int(variables('octets')[2]),2)))]",
+        "subnetWebRange": "[concat( variables('octets')[0], '.', variables('octets')[1], '.', string(add(int(variables('octets')[2]),0)), '.0/24')]"
     }
 }

--- a/docs/Parameters.md
+++ b/docs/Parameters.md
@@ -263,7 +263,7 @@ Possible Values: ["Vpn","ER"]
 Default: Vpn
 
 
-### glusterVmSku
+### fileServerVmSku
 
 VM size for the gluster nodes
 

--- a/nested/gluster.json
+++ b/nested/gluster.json
@@ -36,7 +36,7 @@
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2017-05-10",
             "copy": {
-                "count": "[parameters('moodleCommon').glusterVmCount]",
+                "count": "[parameters('moodleCommon').fileServerVmCount]",
                 "name": "vmloop"
             },
             "dependsOn": [
@@ -66,7 +66,7 @@
         "documentation1": "This sub-template drives the gluster (scale-out network-attached storage file system) creation process.",
         "documentation2": "It expects certain values in the 'common' datastructure.",
         "documentation4": "    gfxAvailabilitySetName  - name of availability set for the gluster farm",
-        "documentation5": "    glusterVmCount          - number of nodes to create",
+        "documentation5": "    fileServerVmCount          - number of nodes to create",
         "documentation6": "This sub-template calls other sub-templates",
         "documentation7": "    glustervm - number of nodes in the gluster farm"
     }

--- a/nested/glustervm.json
+++ b/nested/glustervm.json
@@ -58,7 +58,7 @@
                     "id": "[variables('asRef')]"
                 },
                 "hardwareProfile": {
-                    "vmSize": "[parameters('moodleCommon').glusterVmSku]"
+                    "vmSize": "[parameters('moodleCommon').fileServerVmSku]"
                 },
                 "networkProfile": {
                     "networkInterfaces": [
@@ -169,7 +169,7 @@
         "documentation05": " vnetName                - name of virtual network",
         "documentation06": " subnetSan               - name of subnet for gluster",
         "documentation07": " gfsNameRoot             - nameroot for the gluster nodes - combined with counter to get actual name of each node - disk and nic follow the naming scheme",
-        "documentation08": " glusterVmSku           - VM instance size for gluster nodes",
+        "documentation08": " fileServerVmSku           - VM instance size for gluster nodes",
         "documentation09": " sshUsername           - OS accountusername",
         "documentation10": " osType                  - an array of value that specifies the type of VM",
         "documentation15": "This sub-template calls other sub-templates",

--- a/nested/glustervmsetup.json
+++ b/nested/glustervmsetup.json
@@ -46,13 +46,13 @@
         }
     ],
     "variables": {
-        "cmdExec": "[concat('bash ', parameters('moodleCommon').glusterScriptFilename, ' ', parameters('moodleCommon').gfsNameRoot, ' ', parameters('moodleCommon').subnetSanPrefix, ' data ', parameters('vmNumber'), ' ', parameters('moodleCommon').glusterVmCount)]",
+        "cmdExec": "[concat('bash ', parameters('moodleCommon').glusterScriptFilename, ' ', parameters('moodleCommon').gfsNameRoot, ' ', parameters('moodleCommon').subnetSanPrefix, ' data ', parameters('vmNumber'), ' ', parameters('moodleCommon').fileServerVmCount)]",
         "documentation01": "This sub-template applies a specific post-deployment script to the gluster vms",
         "documentation02": "It expects certain values in the 'common' datastructure.",
         "documentation03": "    scriptLocation        - partial web URI (equivalent to folder)",
         "documentation04": "    glusterScriptFilename - name of script file",
         "documentation06": "    gfsNameRoot           - nameroot of gluster farm - note that the code applies a vmNumber to get to the specific node",
-        "documentation07": "    glusterVmCount        - database (mariadb) password",
+        "documentation07": "    fileServerVmCount     - number of gluster VMs",
         "scriptUri": "[concat(parameters('moodleCommon').scriptLocation,parameters('moodleCommon').glusterScriptFilename,parameters('moodleCommon').artifactsSasToken)]"
     }
 }

--- a/nested/nfs-ha-vm.json
+++ b/nested/nfs-ha-vm.json
@@ -1,0 +1,219 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "vmIndex": {
+            "metadata": {
+                "description": "Index of the VM"
+            },
+            "type": "int"
+        },
+        "location": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "Azure location where this template is to be deployed"
+            }
+        },
+        "subnetId": {
+            "metadata": {
+                "description": "Azure resource ID of the subnet where this NFS-HA cluster is to be deployed"
+            },
+            "type": "string"
+        },
+        "ipAddr": {
+            "metadata": {
+                "description": "Statically assigned private IP that should be assigned to the VM's NIC to be deployed. Must belong to the IP range of the specified subnet"
+            },
+            "type": "string"
+        },
+        "enableAccelNwSwitch": {
+            "metadata": {
+                "description": "Switch to enable Azure Accelerated Networking (Note: this feature is NOT available for D1-level VM SKU)"
+            },
+            "type": "bool",
+            "defaultValue": false
+        },
+        "availSetId": {
+            "metadata": {
+                "description": "Azure resource ID of the availability set where this VM is to be deployed"
+            },
+            "type": "string"
+        },
+        "vmSku": {
+            "metadata": {
+                "description": "Azure VM SKU for the NFS HA VMs"
+            },
+            "type": "string",
+            "defaultValue": "Standard_DS2_v2"
+        },
+        "adminUserName": {
+            "metadata": {
+                "description": "VM admin user name"
+            },
+            "type": "string",
+            "defaultValue": "azureadmin"
+        },
+        "sshPublicKey": {
+            "metadata": {
+                "description": "SSH public key for the admin user"
+            },
+            "type": "string"
+        },
+        "osType": {
+            "metadata": {
+                "description": "OS type (offer/publisher/sku/version) info"
+            },
+            "type": "object"
+        },
+        "osDiskStorageType": {
+            "defaultValue": "Premium_LRS",
+            "allowedValues": [
+                "Premium_LRS",
+                "Standard_LRS"
+            ],
+            "metadata": {
+                "description": "Azure storage type for all VMs' OS disks. With htmlLocalCopySwith true, Premium_LRS (SSD) is strongly recommended, as PHP files will be served from OS disks."
+            },
+            "type": "string"
+        },
+        "dataDiskCountPerVM": {
+            "metadata": {
+                "description": "Number of data disks per VM"
+            },
+            "defaultValue": 2,
+            "minValue": 2,
+            "maxValue": 8,
+            "type": "int"
+        },
+        "dataDiskSizeInGB": {
+            "defaultValue": 32,
+            "metadata": {
+                "description": "Size per disk in an NFS server"
+            },
+            "type": "int"
+        },
+        "resourcesUniqueString": {
+            "metadata": {
+                "description": "Unique string of fixed length (e.g., 6) identifying related resources"
+            },
+            "type": "string",
+            "defaultValue": "[substring(uniqueString(resourceGroup().id, deployment().name), 3, 6)]"
+        },
+        "lbBeId": {
+            "metadata": {
+                "description": "Azure resource ID of the load balancer backend pool to which this VM's NIC should be added"
+            },
+            "type": "string"
+        }
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Network/networkInterfaces",
+            "apiVersion": "2017-10-01",
+            "location": "[parameters('location')]",
+            "name": "[variables('nicName')]",
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "[variables('ipcfgName')]",
+                        "properties": {
+                            "privateIPAllocationMethod": "Static",
+                            "privateIPAddress": "[parameters('ipAddr')]",
+                            "subnet": {
+                                "id": "[parameters('subnetId')]"
+                            },
+                            "loadBalancerBackendAddressPools": [
+                                {
+                                    "id": "[parameters('lbBeId')]"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "enableAcceleratedNetworking": "[parameters('enableAccelNwSwitch')]"
+            },
+            "tags": {
+                "displayName": "[concat('NIC for NFS-HA node', parameters('vmIndex'), ' VM')]"
+            }
+        },
+        {
+            "type": "Microsoft.Compute/virtualMachines",
+            "apiVersion": "2017-03-30",
+            "dependsOn": [
+                "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+            ],
+            "location": "[parameters('location')]",
+            "name": "[variables('vmResourceName')]",
+            "properties": {
+                "availabilitySet": {
+                    "id": "[parameters('availSetId')]"
+                },
+                "hardwareProfile": {
+                    "vmSize": "[parameters('vmSku')]"
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+                        }
+                    ]
+                },
+                "osProfile": {
+                    "adminUsername": "[parameters('adminUserName')]",
+                    "computerName": "[variables('vmName')]",
+                    "linuxConfiguration": {
+                        "disablePasswordAuthentication": true,
+                        "ssh": {
+                            "publicKeys": [
+                                {
+                                    "path": "[concat('/home/', parameters('adminUserName'), '/.ssh/authorized_keys')]",
+                                    "keyData": "[parameters('sshPublicKey')]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "storageProfile": {
+                    "imageReference": "[parameters('osType')]",
+                    "osDisk": {
+                        "createOption": "FromImage",
+                        "managedDisk": {
+                            "storageAccountType": "[parameters('osDiskStorageType')]"
+                        },
+                        "name": "[concat(variables('vmResourceName'), '_osDisk')]"
+                    },
+                    "copy": [
+                        {
+                            "name": "dataDisks",
+                            "count": "[parameters('dataDiskCountPerVM')]",
+                            "input": {
+                                "managedDisk": {
+                                    "storageAccountType": "Premium_LRS"
+                                },
+                                "diskSizeGB": "[parameters('dataDiskSizeInGB')]",
+                                "lun": "[copyIndex('dataDisks')]",
+                                "createOption": "Empty"
+                            }
+                        }
+                    ]
+                }
+            },
+            "tags": {
+                "displayName": "[concat('NFS-HA Virtual Machine', variables('vmName'))]"
+            }
+        }
+    ],
+    "variables": {
+        "nicName": "[concat('nfs-ha-nic', parameters('vmIndex'), '-', parameters('resourcesUniqueString'))]",
+        "ipCfgName": "[concat('nfs-ha-ipcfg', parameters('vmIndex'))]",
+        "vmResourceName": "[concat('nfs-ha-vm', parameters('vmIndex'), '-', parameters('resourcesUniqueString'))]",
+        "vmName": "[concat('nfsnode', parameters('vmIndex'), '-', parameters('resourcesUniqueString'))]"
+    },
+    "outputs": {
+        "ipCfgId": {
+            "value": "[resourceId('Microsoft.Network/networkInterfaces/ipConfigurations', variables('nicName'), variables('ipCfgName'))]",
+            "type": "string"
+        }
+    }
+}

--- a/nested/nfs-ha-vm.json
+++ b/nested/nfs-ha-vm.json
@@ -2,6 +2,19 @@
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
+        "_artifactsLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
+            }
+        },
+        "_artifactsLocationSasToken": {
+            "type": "securestring",
+            "metadata": {
+                "description": "The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated."
+            },
+            "defaultValue": ""
+        },
         "vmIndex": {
             "metadata": {
                 "description": "Index of the VM"
@@ -21,9 +34,15 @@
             },
             "type": "string"
         },
-        "ipAddr": {
+        "ipAddrs": {
             "metadata": {
-                "description": "Statically assigned private IP that should be assigned to the VM's NIC to be deployed. Must belong to the IP range of the specified subnet"
+                "description": "Statically assigned private IP addresses that should be assigned to the two VMs' NICs to be deployed. Must belong to the IP range of the specified subnet"
+            },
+            "type": "array"
+        },
+        "nfsClientsIPRange": {
+            "metadata": {
+                "description": "IP range of the allowed NFS clients. E.g., 10.0.0.0/24"
             },
             "type": "string"
         },
@@ -79,17 +98,17 @@
         },
         "dataDiskCountPerVM": {
             "metadata": {
-                "description": "Number of data disks per VM"
+                "description": "Number of data disks per VM. 2 or more disks will be configured as RAID0"
             },
-            "defaultValue": 2,
-            "minValue": 2,
+            "defaultValue": 1,
+            "minValue": 1,
             "maxValue": 8,
             "type": "int"
         },
         "dataDiskSizeInGB": {
             "defaultValue": 32,
             "metadata": {
-                "description": "Size per disk in an NFS server"
+                "description": "Size of each disk in an NFS server"
             },
             "type": "int"
         },
@@ -119,7 +138,7 @@
                         "name": "[variables('ipcfgName')]",
                         "properties": {
                             "privateIPAllocationMethod": "Static",
-                            "privateIPAddress": "[parameters('ipAddr')]",
+                            "privateIPAddress": "[parameters('ipAddrs')[parameters('vmIndex')]]",
                             "subnet": {
                                 "id": "[parameters('subnetId')]"
                             },
@@ -199,8 +218,36 @@
                     ]
                 }
             },
+            "resources": [
+                {
+                    "type": "extensions",
+                    "apiVersion": "2017-03-30",
+                    "dependsOn": [
+                        "[concat('Microsoft.Compute/virtualMachines/', variables('vmResourceName'))]"
+                    ],
+                    "location": "[parameters('location')]",
+                    "name": "setup_nfs_ha",
+                    "properties": {
+                        "publisher": "Microsoft.Azure.Extensions",
+                        "settings": {
+                            "fileUris": [
+                                "[variables('scriptUri')]",
+                                "[variables('commonFunctionsScriptUri')]"
+                            ]
+                        },
+                        "protectedSettings":{
+                            "commandToExecute": "[variables('cmdExec')]"
+                        },
+                        "type": "CustomScript",
+                        "typeHandlerVersion": "2.0"
+                    },
+                    "tags": {
+                        "displayName": "NFS-HA VM setup CustomScript extension"
+                    }
+                }
+                    ],
             "tags": {
-                "displayName": "[concat('NFS-HA Virtual Machine', variables('vmName'))]"
+                "displayName": "[concat('NFS-HA Virtual Machine ', variables('vmName'))]"
             }
         }
     ],
@@ -208,12 +255,9 @@
         "nicName": "[concat('nfs-ha-nic', parameters('vmIndex'), '-', parameters('resourcesUniqueString'))]",
         "ipCfgName": "[concat('nfs-ha-ipcfg', parameters('vmIndex'))]",
         "vmResourceName": "[concat('nfs-ha-vm', parameters('vmIndex'), '-', parameters('resourcesUniqueString'))]",
-        "vmName": "[concat('nfsnode', parameters('vmIndex'), '-', parameters('resourcesUniqueString'))]"
-    },
-    "outputs": {
-        "ipCfgId": {
-            "value": "[resourceId('Microsoft.Network/networkInterfaces/ipConfigurations', variables('nicName'), variables('ipCfgName'))]",
-            "type": "string"
-        }
+        "vmName": "[concat('hanode', parameters('vmIndex'), '-', parameters('resourcesUniqueString'))]",
+        "scriptUri": "[concat(parameters('_artifactsLocation'), 'scripts/setup_nfs_ha.sh', parameters('_artifactsLocationSasToken'))]",
+        "commonFunctionsScriptUri": "[concat(parameters('_artifactsLocation'), 'scripts/helper_functions.sh', parameters('_artifactsLocationSasToken'))]",
+        "cmdExec": "[concat('bash -x setup_nfs_ha.sh hanode0-', parameters('resourcesUniqueString'), ' ', parameters('ipAddrs')[0], ' hanode1-', parameters('resourcesUniqueString'), ' ', parameters('ipAddrs')[1], ' ', parameters('nfsClientsIPRange'))]"
     }
 }

--- a/nested/nfs-ha.json
+++ b/nested/nfs-ha.json
@@ -6,8 +6,7 @@
             "type": "string",
             "metadata": {
                 "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
-            },
-            "defaultValue": "https://raw.githubusercontent.com/Azure/Moodle/hs-nfs-ha/"
+            }
         },
         "_artifactsLocationSasToken": {
             "type": "securestring",
@@ -38,6 +37,12 @@
         "node1IPAddr": {
             "metadata": {
                 "description": "IP address of node 1 (statically assigned). E.g., 10.0.0.22. Must belong to the IP range of the specified subnet"
+            },
+            "type": "string"
+        },
+        "nfsClientsIPRange": {
+            "metadata": {
+                "description": "IP range of the allowed NFS clients. E.g., 10.0.0.0/24"
             },
             "type": "string"
         },
@@ -99,10 +104,10 @@
         },
         "dataDiskCountPerVM": {
             "metadata": {
-                "description": "Number of data disks per VM"
+                "description": "Number of data disks per VM. 2 or more disks will be configured as RAID0"
             },
-            "defaultValue": 2,
-            "minValue": 2,
+            "defaultValue": 1,
+            "minValue": 1,
             "maxValue": 8,
             "type": "int"
         },
@@ -166,16 +171,130 @@
                 ],
                 "loadBalancingRules": [
                     {
-                        "name": "[variables('nfsHaLbRuleName')]",
+                        "name": "[concat(variables('nfsHaLbRuleName'), 'nfsd-tcp')]",
                         "properties": {
                             "frontendIPConfiguration": {
                                 "id": "[variables('nfsHaLbFeId')]"
                             },
-                            "frontendPort": 80,
+                            "frontendPort": 2049,
                             "backendAddressPool": {
                                 "id": "[variables('nfsHaLbBeId')]"
                             },
-                            "backendPort": 80,
+                            "backendPort": 2049,
+                            "protocol": "Tcp",
+                            "probe": {
+                                "id": "[variables('nfsHaLbProbeId')]"
+                            },
+                            "enableFloatingIP": false,
+                            "idleTimeoutInMinutes": 4
+                        }
+                    },
+                    {
+                        "name": "[concat(variables('nfsHaLbRuleName'), 'rpcbind-tcp')]",
+                        "properties": {
+                            "frontendIPConfiguration": {
+                                "id": "[variables('nfsHaLbFeId')]"
+                            },
+                            "frontendPort": 111,
+                            "backendAddressPool": {
+                                "id": "[variables('nfsHaLbBeId')]"
+                            },
+                            "backendPort": 111,
+                            "protocol": "Tcp",
+                            "probe": {
+                                "id": "[variables('nfsHaLbProbeId')]"
+                            },
+                            "enableFloatingIP": false,
+                            "idleTimeoutInMinutes": 4
+                        }
+                    },
+                    {
+                        "name": "[concat(variables('nfsHaLbRuleName'), 'mountd-tcp')]",
+                        "properties": {
+                            "frontendIPConfiguration": {
+                                "id": "[variables('nfsHaLbFeId')]"
+                            },
+                            "frontendPort": 4002,
+                            "backendAddressPool": {
+                                "id": "[variables('nfsHaLbBeId')]"
+                            },
+                            "backendPort": 4002,
+                            "protocol": "Tcp",
+                            "probe": {
+                                "id": "[variables('nfsHaLbProbeId')]"
+                            },
+                            "enableFloatingIP": false,
+                            "idleTimeoutInMinutes": 4
+                        }
+                    },
+                    {
+                        "name": "[concat(variables('nfsHaLbRuleName'), 'statd-tcp')]",
+                        "properties": {
+                            "frontendIPConfiguration": {
+                                "id": "[variables('nfsHaLbFeId')]"
+                            },
+                            "frontendPort": 4003,
+                            "backendAddressPool": {
+                                "id": "[variables('nfsHaLbBeId')]"
+                            },
+                            "backendPort": 4003,
+                            "protocol": "Tcp",
+                            "probe": {
+                                "id": "[variables('nfsHaLbProbeId')]"
+                            },
+                            "enableFloatingIP": false,
+                            "idleTimeoutInMinutes": 4
+                        }
+                    },
+                    {
+                        "name": "[concat(variables('nfsHaLbRuleName'), 'lockd-tcp')]",
+                        "properties": {
+                            "frontendIPConfiguration": {
+                                "id": "[variables('nfsHaLbFeId')]"
+                            },
+                            "frontendPort": 4004,
+                            "backendAddressPool": {
+                                "id": "[variables('nfsHaLbBeId')]"
+                            },
+                            "backendPort": 4004,
+                            "protocol": "Tcp",
+                            "probe": {
+                                "id": "[variables('nfsHaLbProbeId')]"
+                            },
+                            "enableFloatingIP": false,
+                            "idleTimeoutInMinutes": 4
+                        }
+                    },
+                    {
+                        "name": "[concat(variables('nfsHaLbRuleName'), 'lockd-udp')]",
+                        "properties": {
+                            "frontendIPConfiguration": {
+                                "id": "[variables('nfsHaLbFeId')]"
+                            },
+                            "frontendPort": 4004,
+                            "backendAddressPool": {
+                                "id": "[variables('nfsHaLbBeId')]"
+                            },
+                            "backendPort": 4004,
+                            "protocol": "Udp",
+                            "probe": {
+                                "id": "[variables('nfsHaLbProbeId')]"
+                            },
+                            "enableFloatingIP": false,
+                            "idleTimeoutInMinutes": 4
+                        }
+                    },
+                    {
+                        "name": "[concat(variables('nfsHaLbRuleName'), 'rquotad-tcp')]",
+                        "properties": {
+                            "frontendIPConfiguration": {
+                                "id": "[variables('nfsHaLbFeId')]"
+                            },
+                            "frontendPort": 4005,
+                            "backendAddressPool": {
+                                "id": "[variables('nfsHaLbBeId')]"
+                            },
+                            "backendPort": 4005,
                             "protocol": "Tcp",
                             "probe": {
                                 "id": "[variables('nfsHaLbProbeId')]"
@@ -213,14 +332,23 @@
             "properties": {
                 "mode": "Incremental",
                 "parameters": {
+                    "_artifactsLocation": {
+                        "value": "[parameters('_artifactsLocation')]"
+                    },
+                    "_artifactsLocationSasToken": {
+                        "value": "[parameters('_artifactsLocationSasToken')]"
+                    },
                     "location": {
                         "value": "[parameters('location')]"
                     },
                     "vmIndex": {
                         "value": "[copyindex()]"
                     },
-                    "ipAddr": {
-                        "value": "[variables('nodeIpAddrs')[copyIndex()]]"
+                    "ipAddrs": {
+                        "value": "[variables('nodeIpAddrs')]"
+                    },
+                    "nfsClientsIPRange": {
+                        "value": "[parameters('nfsClientsIPRange')]"
                     },
                     "subnetId": {
                         "value": "[parameters('subnetId')]"

--- a/nested/nfs-ha.json
+++ b/nested/nfs-ha.json
@@ -1,0 +1,284 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "_artifactsLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
+            },
+            "defaultValue": "https://raw.githubusercontent.com/Azure/Moodle/hs-nfs-ha/"
+        },
+        "_artifactsLocationSasToken": {
+            "type": "securestring",
+            "metadata": {
+                "description": "The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated."
+            },
+            "defaultValue": ""
+        },
+        "location": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "Azure location where this template is to be deployed"
+            }
+        },
+        "subnetId": {
+            "metadata": {
+                "description": "Azure resource ID of the subnet where this NFS-HA cluster is to be deployed"
+            },
+            "type": "string"
+        },
+        "node0IPAddr": {
+            "metadata": {
+                "description": "IP address of node 0 (statically assigned). E.g., 10.0.0.11. Must belong to the IP range of the specified subnet"
+            },
+            "type": "string"
+        },
+        "node1IPAddr": {
+            "metadata": {
+                "description": "IP address of node 1 (statically assigned). E.g., 10.0.0.22. Must belong to the IP range of the specified subnet"
+            },
+            "type": "string"
+        },
+        "lbFrontEndIpAddr": {
+            "metadata": {
+                "description": "IP address of the load balancer front-end (statically assigned). E.g., 10.0.0.100. Must belong to the IP range of the specified subnet"
+            },
+            "type": "string"
+        },
+        "enableAccelNwSwitch": {
+            "metadata": {
+                "description": "Switch to enable Azure Accelerated Networking (Note: this feature is NOT available for D1-level VM SKU)"
+            },
+            "type": "bool",
+            "defaultValue": false
+        },
+        "vmSku": {
+            "metadata": {
+                "description": "Azure VM SKU for the NFS HA VMs"
+            },
+            "type": "string",
+            "defaultValue": "Standard_DS2_v2"
+        },
+        "adminUserName": {
+            "metadata": {
+                "description": "VM admin user name"
+            },
+            "type": "string",
+            "defaultValue": "azureadmin"
+        },
+        "sshPublicKey": {
+            "metadata": {
+                "description": "SSH public key for the admin user"
+            },
+            "type": "string"
+        },
+        "osType": {
+            "metadata": {
+                "description": "OS type (offer/publisher/sku/version) info"
+            },
+            "type": "object",
+            "defaultValue": {
+                "offer": "UbuntuServer",
+                "publisher": "Canonical",
+                "sku": "16.04-LTS",
+                "version": "latest"
+            }
+        },
+        "osDiskStorageType": {
+            "defaultValue": "Premium_LRS",
+            "allowedValues": [
+                "Premium_LRS",
+                "Standard_LRS"
+            ],
+            "metadata": {
+                "description": "Azure storage type for all VMs' OS disks. With htmlLocalCopySwith true, Premium_LRS (SSD) is strongly recommended, as PHP files will be served from OS disks."
+            },
+            "type": "string"
+        },
+        "dataDiskCountPerVM": {
+            "metadata": {
+                "description": "Number of data disks per VM"
+            },
+            "defaultValue": 2,
+            "minValue": 2,
+            "maxValue": 8,
+            "type": "int"
+        },
+        "dataDiskSizeInGB": {
+            "defaultValue": 32,
+            "metadata": {
+                "description": "Size per disk in an NFS server"
+            },
+            "type": "int"
+        },
+        "resourcesUniqueString": {
+            "metadata": {
+                "description": "Unique string of fixed length (e.g., 6) identifying related resources"
+            },
+            "type": "string",
+            "defaultValue": "[substring(uniqueString(resourceGroup().id, deployment().name), 3, 6)]"
+        }
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Compute/availabilitySets",
+            "apiVersion": "2017-03-30",
+            "location": "[parameters('location')]",
+            "name": "[variables('availSetName')]",
+            "properties": {
+                "platformFaultDomainCount": 2,
+                "platformUpdateDomainCount": 5
+            },
+            "sku": {
+                "name": "Aligned"
+            },
+            "tags": {
+                "displayName": "NFS-HA Availability Set"
+            }
+        },
+        {
+            "type": "Microsoft.Network/loadBalancers",
+            "sku": {
+                "name": "Basic"
+            },
+            "apiVersion": "2017-10-01",
+            "location": "[parameters('location')]",
+            "name": "[variables('nfsHaLbName')]",
+            "properties": {
+                "frontendIPConfigurations": [
+                    {
+                        "name": "[variables('nfsHaLbFeName')]",
+                        "properties": {
+                            "privateIPAddress": "[parameters('lbFrontEndIpAddr')]",
+                            "privateIPAllocationMethod": "Static",
+                            "subnet": {
+                                "id": "[parameters('subnetId')]"
+                            }
+                        }
+                    }
+                ],
+                "backendAddressPools": [
+                    {
+                        "name": "[variables('nfsHaLbBeName')]"
+                    }
+                ],
+                "loadBalancingRules": [
+                    {
+                        "name": "[variables('nfsHaLbRuleName')]",
+                        "properties": {
+                            "frontendIPConfiguration": {
+                                "id": "[variables('nfsHaLbFeId')]"
+                            },
+                            "frontendPort": 80,
+                            "backendAddressPool": {
+                                "id": "[variables('nfsHaLbBeId')]"
+                            },
+                            "backendPort": 80,
+                            "protocol": "Tcp",
+                            "probe": {
+                                "id": "[variables('nfsHaLbProbeId')]"
+                            },
+                            "enableFloatingIP": false,
+                            "idleTimeoutInMinutes": 4
+                        }
+                    }
+                ],
+                "probes": [
+                    {
+                        "name": "[variables('nfsHaLbProbeName')]",
+                        "properties": {
+                            "intervalInSeconds": 5,
+                            "numberOfProbes": 2,
+                            "port": 61000,
+                            "protocol": "Tcp"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2017-05-10",
+            "copy": {
+                "count": 2,
+                "name": "nfs-ha-vm-loop"
+            },
+            "dependsOn": [
+                "[concat('Microsoft.Compute/availabilitySets/', variables('availSetName'))]",
+                "[concat('Microsoft.Network/loadBalancers/', variables('nfsHaLbName'))]"
+            ],
+            "name": "[concat(variables('vmDeploymentNameBase'), copyIndex())]",
+            "properties": {
+                "mode": "Incremental",
+                "parameters": {
+                    "location": {
+                        "value": "[parameters('location')]"
+                    },
+                    "vmIndex": {
+                        "value": "[copyindex()]"
+                    },
+                    "ipAddr": {
+                        "value": "[variables('nodeIpAddrs')[copyIndex()]]"
+                    },
+                    "subnetId": {
+                        "value": "[parameters('subnetId')]"
+                    },
+                    "enableAccelNwSwitch": {
+                        "value": "[parameters('enableAccelNwSwitch')]"
+                    },
+                    "availSetId": {
+                        "value": "[resourceId('Microsoft.Compute/AvailabilitySets', variables('availSetName'))]"
+                    },
+                    "vmSku": {
+                        "value": "[parameters('vmSku')]"
+                    },
+                    "adminUserName": {
+                        "value": "[parameters('adminUserName')]"
+                    },
+                    "sshPublicKey": {
+                        "value": "[parameters('sshPublicKey')]"
+                    },
+                    "osType": {
+                        "value": "[parameters('osType')]"
+                    },
+                    "osDiskStorageType": {
+                        "value": "[parameters('osDiskStorageType')]"
+                    },
+                    "dataDiskCountPerVM": {
+                        "value": "[parameters('dataDiskCountPerVM')]"
+                    },
+                    "dataDiskSizeInGB": {
+                        "value": "[parameters('dataDiskSizeInGB')]"
+                    },
+                    "resourcesUniqueString": {
+                        "value": "[parameters('resourcesUniqueString')]"
+                    },
+                    "lbBeId": {
+                        "value": "[variables('nfsHaLbBeId')]"
+                    }
+                },
+                "templateLink": {
+                    "uri": "[concat(parameters('_artifactsLocation'), 'nested/nfs-ha-vm.json', parameters('_artifactsLocationSasToken'))]"
+                }
+            }
+        }
+    ],
+    "variables": {
+        "availSetName": "[concat('nfs-ha-availset-', parameters('resourcesUniqueString'))]",
+        "vmDeploymentNameBase": "nfs-ha-vm-deployment",
+        "nodeIpAddrs": [
+            "[parameters('node0IPAddr')]",
+            "[parameters('node1IPAddr')]"
+        ],
+        "nfsHaLbName": "[concat('nfs-ha-lb-', parameters('resourcesUniqueString'))]",
+        "nfsHaLbFeName": "nfs-ha-lb-fe",
+        "nfsHaLbFeId": "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', variables('nfsHaLbName'), variables('nfsHaLbFeName'))]",
+        "nfsHaLbBeName": "nfs-ha-lb-be",
+        "nfsHaLbBeId": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', variables('nfsHaLbName'), variables('nfsHaLbBeName'))]",
+        "nfsHaLbRuleName": "nfs-ha-lb-rule",
+        "nfsHaLbProbeName": "nfs-ha-lb-probe",
+        "nfsHaLbProbeId": "[resourceId('Microsoft.Network/loadBalancers/probes', variables('nfsHaLbName'), variables('nfsHaLbProbeName'))]"
+    }
+}

--- a/nested/nfs-ha.json
+++ b/nested/nfs-ha.json
@@ -171,7 +171,7 @@
                 ],
                 "loadBalancingRules": [
                     {
-                        "name": "[concat(variables('nfsHaLbRuleName'), 'nfsd-tcp')]",
+                        "name": "[concat(variables('nfsHaLbRuleName'), '-nfsd-tcp')]",
                         "properties": {
                             "frontendIPConfiguration": {
                                 "id": "[variables('nfsHaLbFeId')]"
@@ -190,7 +190,26 @@
                         }
                     },
                     {
-                        "name": "[concat(variables('nfsHaLbRuleName'), 'rpcbind-tcp')]",
+                        "name": "[concat(variables('nfsHaLbRuleName'), '-nfsd-udp')]",
+                        "properties": {
+                            "frontendIPConfiguration": {
+                                "id": "[variables('nfsHaLbFeId')]"
+                            },
+                            "frontendPort": 2049,
+                            "backendAddressPool": {
+                                "id": "[variables('nfsHaLbBeId')]"
+                            },
+                            "backendPort": 2049,
+                            "protocol": "Udp",
+                            "probe": {
+                                "id": "[variables('nfsHaLbProbeId')]"
+                            },
+                            "enableFloatingIP": false,
+                            "idleTimeoutInMinutes": 4
+                        }
+                    },
+                    {
+                        "name": "[concat(variables('nfsHaLbRuleName'), '-rpcbind-tcp')]",
                         "properties": {
                             "frontendIPConfiguration": {
                                 "id": "[variables('nfsHaLbFeId')]"
@@ -209,73 +228,16 @@
                         }
                     },
                     {
-                        "name": "[concat(variables('nfsHaLbRuleName'), 'mountd-tcp')]",
+                        "name": "[concat(variables('nfsHaLbRuleName'), '-rpcbind-udp')]",
                         "properties": {
                             "frontendIPConfiguration": {
                                 "id": "[variables('nfsHaLbFeId')]"
                             },
-                            "frontendPort": 4002,
+                            "frontendPort": 111,
                             "backendAddressPool": {
                                 "id": "[variables('nfsHaLbBeId')]"
                             },
-                            "backendPort": 4002,
-                            "protocol": "Tcp",
-                            "probe": {
-                                "id": "[variables('nfsHaLbProbeId')]"
-                            },
-                            "enableFloatingIP": false,
-                            "idleTimeoutInMinutes": 4
-                        }
-                    },
-                    {
-                        "name": "[concat(variables('nfsHaLbRuleName'), 'statd-tcp')]",
-                        "properties": {
-                            "frontendIPConfiguration": {
-                                "id": "[variables('nfsHaLbFeId')]"
-                            },
-                            "frontendPort": 4003,
-                            "backendAddressPool": {
-                                "id": "[variables('nfsHaLbBeId')]"
-                            },
-                            "backendPort": 4003,
-                            "protocol": "Tcp",
-                            "probe": {
-                                "id": "[variables('nfsHaLbProbeId')]"
-                            },
-                            "enableFloatingIP": false,
-                            "idleTimeoutInMinutes": 4
-                        }
-                    },
-                    {
-                        "name": "[concat(variables('nfsHaLbRuleName'), 'lockd-tcp')]",
-                        "properties": {
-                            "frontendIPConfiguration": {
-                                "id": "[variables('nfsHaLbFeId')]"
-                            },
-                            "frontendPort": 4004,
-                            "backendAddressPool": {
-                                "id": "[variables('nfsHaLbBeId')]"
-                            },
-                            "backendPort": 4004,
-                            "protocol": "Tcp",
-                            "probe": {
-                                "id": "[variables('nfsHaLbProbeId')]"
-                            },
-                            "enableFloatingIP": false,
-                            "idleTimeoutInMinutes": 4
-                        }
-                    },
-                    {
-                        "name": "[concat(variables('nfsHaLbRuleName'), 'lockd-udp')]",
-                        "properties": {
-                            "frontendIPConfiguration": {
-                                "id": "[variables('nfsHaLbFeId')]"
-                            },
-                            "frontendPort": 4004,
-                            "backendAddressPool": {
-                                "id": "[variables('nfsHaLbBeId')]"
-                            },
-                            "backendPort": 4004,
+                            "backendPort": 111,
                             "protocol": "Udp",
                             "probe": {
                                 "id": "[variables('nfsHaLbProbeId')]"
@@ -285,17 +247,226 @@
                         }
                     },
                     {
-                        "name": "[concat(variables('nfsHaLbRuleName'), 'rquotad-tcp')]",
+                        "name": "[concat(variables('nfsHaLbRuleName'), '-mountd-tcp')]",
                         "properties": {
                             "frontendIPConfiguration": {
                                 "id": "[variables('nfsHaLbFeId')]"
                             },
-                            "frontendPort": 4005,
+                            "frontendPort": 2000,
                             "backendAddressPool": {
                                 "id": "[variables('nfsHaLbBeId')]"
                             },
-                            "backendPort": 4005,
+                            "backendPort": 2000,
                             "protocol": "Tcp",
+                            "probe": {
+                                "id": "[variables('nfsHaLbProbeId')]"
+                            },
+                            "enableFloatingIP": false,
+                            "idleTimeoutInMinutes": 4
+                        }
+                    },
+                    {
+                        "name": "[concat(variables('nfsHaLbRuleName'), '-mountd-udp')]",
+                        "properties": {
+                            "frontendIPConfiguration": {
+                                "id": "[variables('nfsHaLbFeId')]"
+                            },
+                            "frontendPort": 2000,
+                            "backendAddressPool": {
+                                "id": "[variables('nfsHaLbBeId')]"
+                            },
+                            "backendPort": 2000,
+                            "protocol": "Udp",
+                            "probe": {
+                                "id": "[variables('nfsHaLbProbeId')]"
+                            },
+                            "enableFloatingIP": false,
+                            "idleTimeoutInMinutes": 4
+                        }
+                    },
+                    {
+                        "name": "[concat(variables('nfsHaLbRuleName'), '-statd-tcp')]",
+                        "properties": {
+                            "frontendIPConfiguration": {
+                                "id": "[variables('nfsHaLbFeId')]"
+                            },
+                            "frontendPort": 2001,
+                            "backendAddressPool": {
+                                "id": "[variables('nfsHaLbBeId')]"
+                            },
+                            "backendPort": 2001,
+                            "protocol": "Tcp",
+                            "probe": {
+                                "id": "[variables('nfsHaLbProbeId')]"
+                            },
+                            "enableFloatingIP": false,
+                            "idleTimeoutInMinutes": 4
+                        }
+                    },
+                    {
+                        "name": "[concat(variables('nfsHaLbRuleName'), '-statd-udp')]",
+                        "properties": {
+                            "frontendIPConfiguration": {
+                                "id": "[variables('nfsHaLbFeId')]"
+                            },
+                            "frontendPort": 2001,
+                            "backendAddressPool": {
+                                "id": "[variables('nfsHaLbBeId')]"
+                            },
+                            "backendPort": 2001,
+                            "protocol": "Udp",
+                            "probe": {
+                                "id": "[variables('nfsHaLbProbeId')]"
+                            },
+                            "enableFloatingIP": false,
+                            "idleTimeoutInMinutes": 4
+                        }
+                    },
+                    {
+                        "name": "[concat(variables('nfsHaLbRuleName'), '-statd-outgoing-tcp')]",
+                        "properties": {
+                            "frontendIPConfiguration": {
+                                "id": "[variables('nfsHaLbFeId')]"
+                            },
+                            "frontendPort": 2002,
+                            "backendAddressPool": {
+                                "id": "[variables('nfsHaLbBeId')]"
+                            },
+                            "backendPort": 2002,
+                            "protocol": "Tcp",
+                            "probe": {
+                                "id": "[variables('nfsHaLbProbeId')]"
+                            },
+                            "enableFloatingIP": false,
+                            "idleTimeoutInMinutes": 4
+                        }
+                    },
+                    {
+                        "name": "[concat(variables('nfsHaLbRuleName'), '-statd-outgoing-udp')]",
+                        "properties": {
+                            "frontendIPConfiguration": {
+                                "id": "[variables('nfsHaLbFeId')]"
+                            },
+                            "frontendPort": 2002,
+                            "backendAddressPool": {
+                                "id": "[variables('nfsHaLbBeId')]"
+                            },
+                            "backendPort": 2002,
+                            "protocol": "Udp",
+                            "probe": {
+                                "id": "[variables('nfsHaLbProbeId')]"
+                            },
+                            "enableFloatingIP": false,
+                            "idleTimeoutInMinutes": 4
+                        }
+                    },
+                    {
+                        "name": "[concat(variables('nfsHaLbRuleName'), '-quotad-tcp')]",
+                        "properties": {
+                            "frontendIPConfiguration": {
+                                "id": "[variables('nfsHaLbFeId')]"
+                            },
+                            "frontendPort": 2003,
+                            "backendAddressPool": {
+                                "id": "[variables('nfsHaLbBeId')]"
+                            },
+                            "backendPort": 2003,
+                            "protocol": "Tcp",
+                            "probe": {
+                                "id": "[variables('nfsHaLbProbeId')]"
+                            },
+                            "enableFloatingIP": false,
+                            "idleTimeoutInMinutes": 4
+                        }
+                    },
+                    {
+                        "name": "[concat(variables('nfsHaLbRuleName'), '-quotad-udp')]",
+                        "properties": {
+                            "frontendIPConfiguration": {
+                                "id": "[variables('nfsHaLbFeId')]"
+                            },
+                            "frontendPort": 2003,
+                            "backendAddressPool": {
+                                "id": "[variables('nfsHaLbBeId')]"
+                            },
+                            "backendPort": 2003,
+                            "protocol": "Udp",
+                            "probe": {
+                                "id": "[variables('nfsHaLbProbeId')]"
+                            },
+                            "enableFloatingIP": false,
+                            "idleTimeoutInMinutes": 4
+                        }
+                    },
+                    {
+                        "name": "[concat(variables('nfsHaLbRuleName'), '-lockd-tcp')]",
+                        "properties": {
+                            "frontendIPConfiguration": {
+                                "id": "[variables('nfsHaLbFeId')]"
+                            },
+                            "frontendPort": 2004,
+                            "backendAddressPool": {
+                                "id": "[variables('nfsHaLbBeId')]"
+                            },
+                            "backendPort": 2004,
+                            "protocol": "Tcp",
+                            "probe": {
+                                "id": "[variables('nfsHaLbProbeId')]"
+                            },
+                            "enableFloatingIP": false,
+                            "idleTimeoutInMinutes": 4
+                        }
+                    },
+                    {
+                        "name": "[concat(variables('nfsHaLbRuleName'), '-lockd-udp')]",
+                        "properties": {
+                            "frontendIPConfiguration": {
+                                "id": "[variables('nfsHaLbFeId')]"
+                            },
+                            "frontendPort": 2004,
+                            "backendAddressPool": {
+                                "id": "[variables('nfsHaLbBeId')]"
+                            },
+                            "backendPort": 2004,
+                            "protocol": "Udp",
+                            "probe": {
+                                "id": "[variables('nfsHaLbProbeId')]"
+                            },
+                            "enableFloatingIP": false,
+                            "idleTimeoutInMinutes": 4
+                        }
+                    },
+                    {
+                        "name": "[concat(variables('nfsHaLbRuleName'), '-nfs-callback-tcp')]",
+                        "properties": {
+                            "frontendIPConfiguration": {
+                                "id": "[variables('nfsHaLbFeId')]"
+                            },
+                            "frontendPort": 2005,
+                            "backendAddressPool": {
+                                "id": "[variables('nfsHaLbBeId')]"
+                            },
+                            "backendPort": 2005,
+                            "protocol": "Tcp",
+                            "probe": {
+                                "id": "[variables('nfsHaLbProbeId')]"
+                            },
+                            "enableFloatingIP": false,
+                            "idleTimeoutInMinutes": 4
+                        }
+                    },
+                    {
+                        "name": "[concat(variables('nfsHaLbRuleName'), '-nfs-callback-udp')]",
+                        "properties": {
+                            "frontendIPConfiguration": {
+                                "id": "[variables('nfsHaLbFeId')]"
+                            },
+                            "frontendPort": 2005,
+                            "backendAddressPool": {
+                                "id": "[variables('nfsHaLbBeId')]"
+                            },
+                            "backendPort": 2005,
+                            "protocol": "Udp",
                             "probe": {
                                 "id": "[variables('nfsHaLbProbeId')]"
                             },

--- a/nested/vmsetupparams.json
+++ b/nested/vmsetupparams.json
@@ -80,7 +80,9 @@
                 "type": "[parameters('moodleCommon').fileServerType]",
                 "nfsVmName": "[parameters('moodleCommon').ctlrVmName]",
                 "glusterVmName": "[concat(parameters('moodleCommon').gfsNameRoot, '0')]",
-                "glusterVolName": "data"
+                "glusterVolName": "data",
+                "nfsHaLbIP": "[parameters('moodleCommon').nfsHaLbIP]",
+                "nfsHaExportPath": "[parameters('moodleCommon').nfsHaExportPath]"
             }
         }
     },

--- a/scripts/helper_functions.sh
+++ b/scripts/helper_functions.sh
@@ -57,6 +57,8 @@ function get_setup_params_from_configs_json
     export webServerType=$(echo $json | jq -r .moodleProfile.webServerType)
     export htmlLocalCopySwitch=$(echo $json | jq -r .moodleProfile.htmlLocalCopySwitch)
     export nfsVmName=$(echo $json | jq -r .fileServerProfile.nfsVmName)
+    export nfsHaLbIP=$(echo $json | jq -r .fileServerProfile.nfsHaLbIP)
+    export nfsHaExportPath=$(echo $json | jq -r .fileServerProfile.nfsHaExportPath)
 }
 
 function get_php_version {
@@ -94,8 +96,8 @@ function install_php_mssql_driver
 function check_fileServerType_param
 {
     local fileServerType=$1
-    if [ "$fileServerType" != "gluster" -a "$fileServerType" != "azurefiles" -a "$fileServerType" != "nfs" ]; then
-        echo "Invalid fileServerType ($fileServerType) given. Only 'gluster', 'azurefiles' or 'nfs' are allowed. Exiting"
+    if [ "$fileServerType" != "gluster" -a "$fileServerType" != "azurefiles" -a "$fileServerType" != "nfs" -a "$fileServerType" != "nfs-ha" ]; then
+        echo "Invalid fileServerType ($fileServerType) given. Only 'gluster', 'azurefiles', 'nfs' or 'nfs-ha' are allowed. Exiting"
         exit 1
     fi
 }
@@ -298,8 +300,8 @@ function configure_nfs_server_and_export {
 }
 
 function configure_nfs_client_and_mount {
-    local NFS_SERVER=${1}     # E.g., controller-vm-ab12cd
-    local NFS_DIR=${2}        # E.g., /moodle
+    local NFS_SERVER=${1}     # E.g., controller-vm-ab12cd or IP (NFS-HA LB)
+    local NFS_DIR=${2}        # E.g., /moodle or /drbd/data
     local MOUNTPOINT=${3}     # E.g., /moodle
 
     apt install -y nfs-common

--- a/scripts/install_moodle.sh
+++ b/scripts/install_moodle.sh
@@ -155,6 +155,10 @@
         # mount gluster files system
         echo -e '\n\rInstalling GlusterFS on '$glusterNode':/'$glusterVolume '/moodle\n\r' 
         setup_and_mount_gluster_moodle_share $glusterNode $glusterVolume
+    elif [ $fileServerType = "nfs-ha" ]; then
+        # mount NFS-HA export
+        echo -e '\n\rMounting NFS export from '$nfsHaLbIP' on /moodle\n\r'
+        configure_nfs_client_and_mount $nfsHaLbIP $nfsHaExportPath /moodle
     fi
     
     # install pre-requisites
@@ -890,7 +894,7 @@ EOF
    service varnishncsa stop
    service varnishlog stop
 
-   if [ $fileServerType = "gluster" -o $fileServerType = "nfs" ]; then
+   if [ $fileServerType = "gluster" -o $fileServerType = "nfs" -o $fileServerType = "nfs-ha" ]; then
       # make sure Moodle can read its code directory but not write
       sudo chown -R root.root /moodle/html/moodle
       sudo find /moodle/html/moodle -type f -exec chmod 644 '{}' \;

--- a/scripts/install_moodle.sh
+++ b/scripts/install_moodle.sh
@@ -98,7 +98,7 @@
         sudo add-apt-repository ppa:gluster/glusterfs-3.8 -y                 >> /tmp/apt1.log
     elif [ $fileServerType = "nfs" ]; then
         # configure NFS server and export
-        create_filesystem_with_raid /moodle /dev/md1 /dev/md1p1
+        setup_raid_disk_and_filesystem /moodle /dev/md1 /dev/md1p1
         configure_nfs_server_and_export /moodle
     fi
 

--- a/scripts/setup_nfs_ha.sh
+++ b/scripts/setup_nfs_ha.sh
@@ -1,0 +1,229 @@
+#!/bin/bash
+#
+# Script to set up highly available NFS server on an Ubuntu 16.04 (or higher) VM
+# that should be used on Azure with the custom script extension (which runs this script as root)
+#
+
+set -e
+
+# Parameters
+NODE1NAME=$1
+NODE1IP=$2
+NODE2NAME=$3
+NODE2IP=$4
+NFS_CLIENTS_IP_RANGE=$5     # E.g., "10.0.0.0/24". Can be "*", but strongly discouraged
+
+# This VM's IP address, to detect if this VM should be the master (Node 1 is the initial master)
+MY_IP=$(hostname -i)
+
+. ./helper_functions.sh
+
+function setup_required_packages
+{
+    apt update
+    apt -y install build-essential autoconf flex nfs-kernel-server corosync pacemaker resource-agents
+
+    # Shouldn't let systemd start nfs-kernel-server (Pacemaker should do that)
+    systemctl stop nfs-kernel-server
+    systemctl disable nfs-kernel-server
+
+    # We need to install the "azure-lb" command separately if the resource-agents package didn't have it.
+    pushd /usr/lib/ocf/resource.d/heartbeat
+    if [ ! -e azure-lb ]; then
+        curl -LO https://raw.githubusercontent.com/ClusterLabs/resource-agents/master/heartbeat/azure-lb
+        chmod +x ./azure-lb
+    fi
+    popd
+}
+
+function setup_drbd_module_and_tools
+{
+    # We currently have to build the DRBD kernel module, as it's not included
+    # in the default linux-azure kernels or in any Azure extra packages.
+    # We should use the packaged DRBD module once Azure starts releasing
+    # extra modules packages that include DRBD module.
+
+    pushd /tmp
+    git clone http://github.com/LINBIT/drbd-9.0
+    git clone http://github.com/LINBIT/drbd-utils
+    cd drbd-9.0
+    make && make install
+    modprobe drbd
+    cd ../drbd-utils
+    ./autogen.sh
+    ./configure --prefix=/usr --localstatedir=/var --sysconfdir=/etc
+    make tools && make install-tools
+    cd ..
+    rm -rf drbd-9.0 drbd-utils
+    popd
+}
+
+function setup_drbd_with_disk
+{
+    local disk=$1
+    local node1name=$2
+    local node1ip=$3
+    local node2name=$4
+    local node2ip=$5
+    local drbd_resource_name=$6
+    local drbd_device_path=$7
+    local drbd_device_mount_point=$8
+
+    # Put LVM (to gain more flexibility) on the whole disk
+    local vgname=drbdvg
+    local lvname=drbdlv
+    wipefs -af $disk
+    pvcreate $disk
+    vgcreate $vgname $disk
+    lvcreate -n $lvname -l 95%VG $vgname
+
+    # Set up DRBD config
+    cat <<EOF > /etc/drbd.d/${drbd_resource_name}.res
+resource $drbd_resource_name {
+    device      ${drbd_device_path};
+    disk        /dev/${vgname}/${lvname};
+    meta-disk   internal;
+    on ${node1name} {
+        address ${node1ip}:7789;
+    }
+    on ${node2name} {
+        address ${node2ip}:7789;
+    }
+}
+EOF
+
+    # Initialize DRBD's metadata and bring up the device on both nodes
+    drbdadm create-md $drbd_resource_name
+    drbdadm up $drbd_resource_name
+    drbdadm status
+
+    # On the master (initially node 1) only, force DRBD into Primary and create an ext4 file system on the DRBD device
+    if [ "$MY_IP" = "$NODE1IP" ]; then
+        drbdadm primary $drbd_resource_name --force
+        mkfs.ext4 $drbd_device_path
+        mkdir -p $drbd_device_mount_point && mount $drbd_device_path $drbd_device_mount_point
+    fi
+}
+
+function setup_corosync_and_pacemaker_for_nfs
+{
+    local node1ip=$1
+    local node2ip=$2
+    local drbd_resource_name=$3     # E.g., azmdlr0
+    local drbd_device_path=$4       # E.g., /dev/drbd0
+    local drbd_mount_point=$5       # E.g., /drbd
+    local nfs_export_path=$6        # E.g., /drbd/moodle
+    local nfs_client_spec=$7        # E.g., * or 10.11.22.0/24
+
+    mv /etc/corosync/corosync.conf /etc/corosync/corosync.conf.orig || true
+    
+    local cluster_name=azmdl-cluster
+
+    cat <<EOF > /etc/corosync/corosync.conf
+totem {
+    version: 2
+    secauth: off
+    cluster_name: ${cluster_name}
+    transport: udpu
+}
+
+nodelist {
+    node {
+        ring0_addr: ${node1ip}
+        nodeid: 1
+    }
+    node {
+        ring0_addr: ${node2ip}
+        nodeid: 2
+    }
+}
+
+quorum {
+    provider: corosync_votequorum
+    two_node:1
+}
+
+logging {
+    to_syslog: yes
+}
+EOF
+
+    systemctl enable corosync pacemaker
+    systemctl start corosync pacemaker
+
+    # Work around the issue of corosync bound to loopback address (127.0.0.1) by restarting it (suggested in DRBD HA Azure guide)
+    sleep 5 && systemctl restart corosync
+    # TODO Should confirm if 'corosync-cfgtool -s' gives a non-loopback IP address, e.g.:
+    # $ corosync-cfgtool -s
+    # Printing ring status.
+    # Local node ID 2
+    # RING ID 0
+    #     id = 10.0.0.5
+    #     status = ring 0 active with no faults
+
+    # Finally, configure Pacemaker cluster resources, only on the initial master
+    if [ "$MY_IP" = "$node1ip" ]; then
+        mkdir -p ${nfs_export_path}
+        crm configure <<EOF
+primitive p_drbd_r0 ocf:linbit:drbd \
+    params drbd_resource=${drbd_resource_name} \
+    op monitor interval=29s role=Master \
+    op monitor interval=31s role=Slave \
+    op start interval=0s timeout=240s \
+    op stop interval=0s timeout=100s
+ms ms_drbd_r0 p_drbd_r0 \
+    meta master-max=1 master-node-max=1 clone-node-max=1 clone-max=2 notify=true
+primitive p_fs_data Filesystem \
+    params device="${drbd_device_path}" directory="${drbd_mount_point}" \
+    fstype=ext4 options=noatime,nodiratime \
+    op start interval=0s timeout=100s \
+    op stop interval=0s timeout=100s \
+    op monitor interval=10s timeout=100s
+primitive p_nfsserver ocf:heartbeat:nfsserver \
+    params nfs_shared_infodir="${drbd_mount_point}/nfs_shared_infodir" \
+    op start interval=0s timeout=40s \
+    op stop interval=0s timeout=20s \
+    op monitor interval=10s timeout=20s
+primitive p_exportfs ocf:heartbeat:exportfs \
+    params clientspec="${nfs_client_spec}" directory="${nfs_export_path}" fsid=1 \
+    unlock_on_stop=1 options=rw,sync \
+    op start interval=0s timeout=40s \
+    op stop interval=0s timeout=120s \
+    op monitor interval=10s timeout=20s
+primitive p_azure-lb azure-lb \
+    params nc="/bin/nc" port="61000" \
+    op start interval=0s timeout=20s \
+    op stop interval=0s timeout=20s \
+    op monitor interval=10s timeout=20s
+group g_services p_fs_data p_nfsserver p_exportfs p_azure-lb
+colocation cl-g_services-with-ms_drbd_r0 inf: g_services ms_drbd_r0:Master
+order o-ms_drbd_r0-before-g_services inf: ms_drbd_r0:promote g_services:start
+property stonith-enabled=false
+EOF
+    fi
+    # TODO STONITH is disabled for now (two lines above). Should enable it soon.
+
+    # TODO 'crm_mon -r' should show the correctly configured/started cluster resources.
+}
+
+# Main
+
+setup_required_packages
+
+setup_drbd_module_and_tools
+
+# Don't create a file system, but just set up a disk (RAID if multiple unpartitioned disks)
+# AZMDL_DISK env var is set by the function as the discovered/initialized disk
+setup_raid_disk_and_filesystem None /dev/md0 None False
+
+DRBD_RESOURCE_NAME=azmdlr0
+DRBD_DEVICE_PATH=/dev/drbd0
+DRBD_MOUNT_POINT=/drbd
+
+setup_drbd_with_disk $AZMDL_DISK $NODE1NAME $NODE1IP $NODE2NAME $NODE2IP $DRBD_RESOURCE_NAME $DRBD_DEVICE_PATH $DRBD_MOUNT_POINT
+
+NFS_EXPORT_PATH=${DRBD_MOUNT_POINT}/moodle  # TODO Allow different export dir name
+
+setup_corosync_and_pacemaker_for_nfs $NODE1IP $NODE2IP $DRBD_RESOURCE_NAME $DRBD_DEVICE_PATH $DRBD_MOUNT_POINT $NFS_EXPORT_PATH "$NFS_CLIENTS_IP_RANGE"
+
+echo "NFS-HA setup succeeded. NFS_EXPORT_PATH=${NFS_EXPORT_PATH}, NFS_CLIENT_SPEC=${NFS_CLIENT_SPEC}"

--- a/scripts/setup_nfs_ha.sh
+++ b/scripts/setup_nfs_ha.sh
@@ -246,3 +246,7 @@ NFS_EXPORT_PATH=${DRBD_MOUNT_POINT}/moodle  # TODO Allow different export dir na
 setup_corosync_and_pacemaker_for_nfs $NODE1IP $NODE2IP $DRBD_RESOURCE_NAME $DRBD_DEVICE_PATH $DRBD_MOUNT_POINT $NFS_EXPORT_PATH "$NFS_CLIENTS_IP_RANGE"
 
 echo "NFS-HA setup succeeded. NFS_EXPORT_PATH=${NFS_EXPORT_PATH}, NFS_CLIENT_SPEC=${NFS_CLIENT_SPEC}"
+
+# TODO The persistent NFS port assignments don't work until rebooted for unknown reasons. Fix this later.
+echo "Restarting the machine in 1 minute to work around the persistent NFS port assignments problem..."
+shutdown -r +1

--- a/scripts/setup_nfs_ha.sh
+++ b/scripts/setup_nfs_ha.sh
@@ -195,7 +195,7 @@ primitive p_nfsserver ocf:heartbeat:nfsserver \
     op monitor interval=10s timeout=20s
 primitive p_exportfs ocf:heartbeat:exportfs \
     params clientspec="${nfs_client_spec}" directory="${nfs_export_path}" fsid=1 \
-    unlock_on_stop=1 options=rw,sync \
+    unlock_on_stop=1 options=rw,sync,no_root_squash \
     op start interval=0s timeout=40s \
     op stop interval=0s timeout=120s \
     op monitor interval=10s timeout=20s

--- a/scripts/setup_nfs_ha.sh
+++ b/scripts/setup_nfs_ha.sh
@@ -236,3 +236,7 @@ NFS_EXPORT_PATH=${DRBD_MOUNT_POINT}/moodle  # TODO Allow different export dir na
 setup_corosync_and_pacemaker_for_nfs $NODE1IP $NODE2IP $DRBD_RESOURCE_NAME $DRBD_DEVICE_PATH $DRBD_MOUNT_POINT $NFS_EXPORT_PATH "$NFS_CLIENTS_IP_RANGE"
 
 echo "NFS-HA setup succeeded. NFS_EXPORT_PATH=${NFS_EXPORT_PATH}, NFS_CLIENT_SPEC=${NFS_CLIENT_SPEC}"
+
+# TODO The persistent NFS port assignments don't work until rebooted for unknown reasons. Fix this later.
+echo "Restarting the machine in 1 minute to work around the persistent NFS port assignments problem..."
+shutdown -r +1

--- a/scripts/setup_nfs_ha.sh
+++ b/scripts/setup_nfs_ha.sh
@@ -27,6 +27,13 @@ function setup_required_packages
     systemctl stop nfs-kernel-server
     systemctl disable nfs-kernel-server
 
+    # Setup static port assignments for mountd, nlm (tcp), and nlm (udp) respectively:
+	sed -i 's/^\(RPCMOUNTDOPTS="--manage-gids\)"/\1 -p 2000"/g' /etc/default/nfs-kernel-server
+	cat <<EOF > /etc/sysctl.d/30-nfs-ports.conf
+fs.nfs.nlm_tcpport = 2001
+fs.nfs.nlm_udpport = 2002
+EOF
+
     # We need to install the "azure-lb" command separately if the resource-agents package didn't have it.
     pushd /usr/lib/ocf/resource.d/heartbeat
     if [ ! -e azure-lb ]; then

--- a/scripts/setup_nfs_ha.sh
+++ b/scripts/setup_nfs_ha.sh
@@ -235,13 +235,13 @@ setup_drbd_module_and_tools
 # AZMDL_DISK env var is set by the function as the discovered/initialized disk
 setup_raid_disk_and_filesystem None /dev/md0 None False
 
-DRBD_RESOURCE_NAME=azmdlr0
+DRBD_RESOURCE_NAME=azmdlr0   # TODO Avoid hard-coded value
 DRBD_DEVICE_PATH=/dev/drbd0
-DRBD_MOUNT_POINT=/drbd
+DRBD_MOUNT_POINT=/drbd       # TODO Avoid hard-coded value
 
 setup_drbd_with_disk $AZMDL_DISK $NODE1NAME $NODE1IP $NODE2NAME $NODE2IP $DRBD_RESOURCE_NAME $DRBD_DEVICE_PATH $DRBD_MOUNT_POINT
 
-NFS_EXPORT_PATH=${DRBD_MOUNT_POINT}/moodle  # TODO Allow different export dir name
+NFS_EXPORT_PATH=${DRBD_MOUNT_POINT}/data  # TODO Allow different export dir name -- This requires changes all along the pipeline, from the top-level template to this script...
 
 setup_corosync_and_pacemaker_for_nfs $NODE1IP $NODE2IP $DRBD_RESOURCE_NAME $DRBD_DEVICE_PATH $DRBD_MOUNT_POINT $NFS_EXPORT_PATH "$NFS_CLIENTS_IP_RANGE"
 

--- a/scripts/setup_webserver.sh
+++ b/scripts/setup_webserver.sh
@@ -94,7 +94,13 @@ check_fileServerType_param $fileServerType
     sudo echo -e 'Adding Gluster FS to /etc/fstab and mounting it'
     setup_and_mount_gluster_moodle_share $glusterNode $glusterVolume
   elif [ $fileServerType = "nfs" ]; then
+    # mount NFS export (set up on controller VM--No HA)
+    echo -e '\n\rMounting NFS export from '$nfsVmName':/moodle on /moodle and adding it to /etc/fstab\n\r'
     configure_nfs_client_and_mount $nfsVmName /moodle /moodle
+  elif [ $fileServerType = "nfs-ha" ]; then
+    # mount NFS-HA export
+    echo -e '\n\rMounting NFS export from '$nfsHaLbIP':'$nfsHaExportPath' on /moodle and adding it to /etc/fstab\n\r'
+    configure_nfs_client_and_mount $nfsHaLbIP $nfsHaExportPath /moodle
   else # "azurefiles"
     setup_and_mount_azure_files_moodle_share $storageAccountName $storageAccountKey
   fi


### PR DESCRIPTION
(@rgardler -- Just an informational PR, no need to review. I manually validated that this feature works.)

Implements the highly available NFS cluster as a file server type option. Uses DRBD and Pacemaker/Corosync to implement active-passive (master-slave) failover NFS cluster. Usual/non-cloud way is to use a fixed secondary IP address that can fail over from one machine to the other, but on clouds (at least Azure), even secondary IP address must be assigned to a specific VM on the cloud platform, so we had to use a load balancer-based solution like implemented here.

Huge thanks to @kermat from LINBIT who helped tremendously (even with an Azure dedicated guide document) while I was struggling with getting the HA clustering right.

There are a few things to address in the future:

- STONITH is disabled, so split-brain can occur. STONITH on clouds requires something more sophisticated, and @kermat already shared an idea
- Currently the DRBD replication traffic uses the same NIC, which might add congestion to the overall network performance. I'll also need to perform some load testing on this file server option, to see if this is really (or how much) better than Gluster, and if this is comparable to the non-HA NFS option.
- When testing fail-over, I experienced some prolonged period (about a minute) during which accessing files on NFS share is seemingly hung. I observed that a cluster failover is really quick, but the actual file access after a failover occurs seems delayed. Need to investigate why.
- Currently the DRBD kernel module is compiled/installed at the deployment time, because Linux-azure kernels don't ship the DRBD kernel module by default. This will be problematic when the kernel is upgraded and the VM is rebooted. We need to make sure the module is available through Azure Ubuntu repos and the module upgrades should always accompany kernel upgrades.

I tried to make the added templates as independent as possible so that they can be added to the Azure quick start templates repo without any modification. I'll do that once we have a few more working test deployment experiences.
