### PR TITLE
Missing replacement after search-elastic-config.json renaming

### DIFF
--- a/nested/search-elastic.json
+++ b/nested/search-elastic.json
@@ -107,7 +107,7 @@
 
                 },
                 "templateLink": {
-                    "uri": "[concat(parameters('moodleCommon').baseTemplateUrl,'elasticconfig.json',parameters('moodleCommon').artifactsSasToken)]"
+                    "uri": "[concat(parameters('moodleCommon').baseTemplateUrl,'search-elastic-config.json',parameters('moodleCommon').artifactsSasToken)]"
                 }
             }
         },
@@ -343,7 +343,7 @@
 
                 },
                 "templateLink": {
-                    "uri": "[concat(parameters('moodleCommon').baseTemplateUrl,'elasticconfig.json',parameters('moodleCommon').artifactsSasToken)]"
+                    "uri": "[concat(parameters('moodleCommon').baseTemplateUrl,'search-elastic-config.json',parameters('moodleCommon').artifactsSasToken)]"
                 }
             }
         },


### PR DESCRIPTION
Only elastic search VM 2 was updated to point on the search-elastic-config.json instead of elasticconfig.json