### PR TITLE
AppGw V2 

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -451,13 +451,15 @@
             "type": "string"
         },
         "appGwSkuName": {
-            "defaultValue": "Standard_Medium",
+            "defaultValue": "Standard_v2",
             "allowedValues": [
                 "Standard_Small",
                 "Standard_Medium",
                 "Standard_Large",
+                "Standard_v2",
                 "WAF_Medium",
-                "WAF_Large"
+                "WAF_Large",
+                "WAF_v2"
             ],
             "metadata": {
                 "description": "(App Gateway https termination only) Name of the Applicate Gateway SKU"
@@ -465,10 +467,12 @@
             "type": "string"
         },
         "appGwSkuTier": {
-            "defaultValue": "Standard",
+            "defaultValue": "Standard_v2",
             "allowedValues": [
                 "Standard",
-                "WAF"
+                "Standard_v2",
+                "WAF",
+                "WAF_v2"
             ],
             "metadata": {
                 "description": "(App Gateway https termination only) Tier of the Applicate Gateway"

--- a/nested/appgw.json
+++ b/nested/appgw.json
@@ -26,7 +26,7 @@
             "type": "Microsoft.Network/applicationGateways",
             "name": "[parameters('moodleCommon').appGwName]",
             "location": "[parameters('moodleCommon').location]",
-            "apiVersion": "2018-02-01",
+            "apiVersion": "2019-11-01",
             "properties": {
                 "sku": {
                     "name": "[parameters('moodleCommon').appGwSkuName]",

--- a/nested/appgw.json
+++ b/nested/appgw.json
@@ -119,6 +119,19 @@
                         }
                     }
                 ],
+                "redirectConfigurations": [
+                    {
+                        "name": "httpToHttps",
+                        "properties": {
+                            "redirectType":"Permanent",
+                            "includePath" : true,
+                            "includeQueryString" : true,
+                            "targetListener": {
+                                "id": "[concat(variables('appGwID'), '/httpListeners/appGwHttpsListener')]"
+                            }
+                        }
+                    }
+                ],                
                 "requestRoutingRules": [
                     {
                         "Name": "rule1",

--- a/nested/appgw.json
+++ b/nested/appgw.json
@@ -55,11 +55,17 @@
                 ],
                 "frontendPorts": [
                     {
-                        "name": "appGwFrontendPort",
+                        "name": "httpsFrontendPort",
                         "properties": {
                             "port": 443
                         }
-                    }
+                    },
+                    {
+                        "name": "httpFrontendPort",
+                        "properties": {
+                            "port": 80
+                        }
+                    }                    
                 ],
                 "backendAddressPools": [
                     {
@@ -92,7 +98,7 @@
                                 "Id": "[concat(variables('appGwID'), '/frontendIPConfigurations/appGwFrontendIP')]"
                             },
                             "frontendPort": {
-                                "Id": "[concat(variables('appGwID'), '/frontendPorts/appGwFrontendPort')]"
+                                "Id": "[concat(variables('appGwID'), '/frontendPorts/httpsFrontendPort')]"
                             },
                             "protocol": "Https",
                             "sslCertificate": {

--- a/nested/appgw.json
+++ b/nested/appgw.json
@@ -92,7 +92,7 @@
                 ],
                 "httpListeners": [
                     {
-                        "name": "appGwHttpListener",
+                        "name": "appGwHttpsListener",
                         "properties": {
                             "frontendIPConfiguration": {
                                 "Id": "[concat(variables('appGwID'), '/frontendIPConfigurations/appGwFrontendIP')]"
@@ -104,6 +104,18 @@
                             "sslCertificate": {
                                 "Id": "[concat(variables('appGwID'), '/sslCertificates/appGatewaySslCert')]"
                             }
+                        }
+                    },
+                    {
+                        "name": "appGwHttpListener",
+                        "properties": {
+                            "frontendIPConfiguration": {
+                                "Id": "[concat(variables('appGwID'), '/frontendIPConfigurations/appGwFrontendIP')]"
+                            },
+                            "frontendPort": {
+                                "Id": "[concat(variables('appGwID'), '/frontendPorts/httpFrontendPort')]"
+                            },
+                            "protocol": "Http"
                         }
                     }
                 ],

--- a/nested/appgw.json
+++ b/nested/appgw.json
@@ -134,17 +134,29 @@
                 ],                
                 "requestRoutingRules": [
                     {
-                        "Name": "rule1",
+                        "Name": "httpsRule",
                         "properties": {
                             "ruleType": "Basic",
                             "httpListener": {
-                                "id": "[concat(variables('appGwID'), '/httpListeners/appGwHttpListener')]"
+                                "id": "[concat(variables('appGwID'), '/httpListeners/appGwHttpsListener')]"
                             },
                             "backendAddressPool": {
                                 "id": "[concat(variables('appGwID'), '/backendAddressPools/', variables('appGwBePoolName'))]"
                             },
                             "backendHttpSettings": {
                                 "id": "[concat(variables('appGwID'), '/backendHttpSettingsCollection/appGwBackendHttpSettings')]"
+                            }
+                        }
+                    },
+                    {
+                        "Name": "httpRedirectRule",
+                        "properties": {
+                            "ruleType": "Basic",
+                            "httpListener": {
+                                "id": "[concat(variables('appGwID'), '/httpListeners/appGwHttpListener')]"
+                            },
+                            "redirectConfiguration": {
+                                "id": "[concat(variables('appGwID'), '/redirectConfigurations/httpToHttps')]"
                             }
                         }
                     }

--- a/nested/network.json
+++ b/nested/network.json
@@ -154,15 +154,14 @@
             "apiVersion": "2019-11-01",
             "location": "[parameters('moodleCommon').location]",
             "name": "[parameters('moodleCommon').appGwPipName]",
-            "sku" : "[if(endswith(parameters('moodleCommon').appGwSkuName,'v2'),'Standard','Basic')]",
+            "sku" : {
+                "name" : "[if(endswith(parameters('moodleCommon').appGwSkuName,'v2'),'Standard','Basic')]"
+            },
             "properties": {                
                 "dnsSettings": {
                     "domainNameLabel": "[parameters('moodleCommon').appGwName]"
                 },
                 "publicIPAllocationMethod": "[if(endswith(parameters('moodleCommon').appGwSkuName,'v2'),'Static','Dynamic')]"
-            },
-            "tags": {
-                "displayName": "App Gateway Public IP (must be dynamic)"
             }
         },
         {

--- a/nested/network.json
+++ b/nested/network.json
@@ -154,11 +154,12 @@
             "apiVersion": "2019-11-01",
             "location": "[parameters('moodleCommon').location]",
             "name": "[parameters('moodleCommon').appGwPipName]",
-            "properties": {
+            "sku" : "[if(endswith(parameters('moodleCommon').appGwSkuName,'v2'),'Standard','Basic')]",
+            "properties": {                
                 "dnsSettings": {
                     "domainNameLabel": "[parameters('moodleCommon').appGwName]"
                 },
-                "publicIPAllocationMethod": "Dynamic"
+                "publicIPAllocationMethod": "[if(endswith(parameters('moodleCommon').appGwSkuName,'v2'),'Static','Dynamic')]"
             },
             "tags": {
                 "displayName": "App Gateway Public IP (must be dynamic)"

--- a/nested/network.json
+++ b/nested/network.json
@@ -83,7 +83,7 @@
         {
             "condition": "[parameters('moodleCommon').vnetGwDeploySwitch]",
             "type": "Microsoft.Network/publicIPAddresses",
-            "apiVersion": "2017-10-01",
+            "apiVersion": "2019-11-01",
             "location": "[parameters('moodleCommon').location]",
             "name": "[parameters('moodleCommon').gatewayPublicIPName]",
             "properties": {
@@ -135,7 +135,7 @@
             "sku": {
                 "name": "[parameters('moodleCommon').lbSku]"
             },
-            "apiVersion": "2017-10-01",
+            "apiVersion": "2019-11-01",
             "location": "[parameters('moodleCommon').location]",
             "name": "[parameters('moodleCommon').lbPipName]",
             "properties": {
@@ -151,7 +151,7 @@
         {
             "condition": "[equals(parameters('moodleCommon').httpsTermination, 'AppGw')]",
             "type": "Microsoft.Network/publicIPAddresses",
-            "apiVersion": "2017-10-01",
+            "apiVersion": "2019-11-01",
             "location": "[parameters('moodleCommon').location]",
             "name": "[parameters('moodleCommon').appGwPipName]",
             "properties": {
@@ -166,7 +166,7 @@
         },
         {
             "type": "Microsoft.Network/publicIPAddresses",
-            "apiVersion": "2017-10-01",
+            "apiVersion": "2019-11-01",
             "location": "[parameters('moodleCommon').location]",
             "name": "[parameters('moodleCommon').ctlrPipName]",
             "properties": {


### PR DESCRIPTION
Hi Team,

These changes set the AppGW to default to version V2, which is a huge upgrade on V1. V1 is still a deployment option. 

I've tested the deployment on both AppGw V1 and V2 Standard versions and they both seem to work.

V2 Parameters were added to appGwSkuName and appGwSkuTier. Conditions were added to the appGwPip object, to select the correct Public IP Sku and Allocation method for the deployment, based upon the appGwSkuName parameter.

One question I have, is that in the network.json file, the nested AppGw deployment has a dependsOn for the lbPipName.  Should that dependsOn be for the AppGwIp and if so, why does it work with the lbPipName?