### PR TITLE
Mitigate performance issues through cache configuration and other improvements.

### DIFF
--- a/azuredeploy-large-ha.json
+++ b/azuredeploy-large-ha.json
@@ -31,17 +31,42 @@
             "properties": {
                 "mode": "Incremental",
                 "parameters": {
-                    "_artifactsLocation":           { "value": "[parameters('_artifactsLocation')]" },
-                    "_artifactsLocationSasToken":   { "value": "[parameters('_artifactsLocationSasToken')]" },
-                    "redisDeploySwitch":            { "value": true },
-                    "sshPublicKey":                 { "value": "[parameters('sshPublicKey')]" },
-                    "autoscaleVmCountMax":          { "value": 20 },
-		    "autoscaleVmSku":		    { "value": "Standard_DS3_v2" },
-                    "mysqlPgresVcores":             { "value": 16 },
-                    "mysqlPgresStgSizeGB":          { "value": 512 },
-                    "fileServerType":               { "value": "azurefiles" },
-                    "fileServerDiskSize":           { "value": 1024 },
-                    "storageAccountType":           { "value": "Premium_LRS" }
+                    "_artifactsLocation": {
+                        "value": "[parameters('_artifactsLocation')]"
+                    },
+                    "_artifactsLocationSasToken": {
+                        "value": "[parameters('_artifactsLocationSasToken')]"
+                    },
+                    "loadBalancerSku": {
+                        "value": "Standard"
+                    },
+                    "redisDeploySwitch": {
+                        "value": true
+                    },
+                    "sshPublicKey": {
+                        "value": "[parameters('sshPublicKey')]"
+                    },
+                    "autoscaleVmCountMax": {
+                        "value": 20
+                    },
+                    "autoscaleVmSku": {
+                        "value": "Standard_DS3_v2"
+                    },
+                    "mysqlPgresVcores": {
+                        "value": 16
+                    },
+                    "mysqlPgresStgSizeGB": {
+                        "value": 512
+                    },
+                    "fileServerType": {
+                        "value": "azurefiles"
+                    },
+                    "fileServerDiskSize": {
+                        "value": 1024
+                    },
+                    "storageAccountType": {
+                        "value": "Premium_LRS"
+                    }
                 },
                 "templateLink": {
                     "uri": "[concat(parameters('_artifactsLocation'), 'azuredeploy.json', parameters('_artifactsLocationSasToken'))]"

--- a/nested/controller.json
+++ b/nested/controller.json
@@ -139,6 +139,7 @@
                     "imageReference": "[parameters('moodleCommon').osType]",
                     "osDisk": {
                         "createOption": "FromImage",
+                        "diskSizeGB": 256,
                         "managedDisk": {
                             "storageAccountType": "[parameters('moodleCommon').osDiskStorageType]"
                         },

--- a/nested/controller.json
+++ b/nested/controller.json
@@ -139,7 +139,7 @@
                     "imageReference": "[parameters('moodleCommon').osType]",
                     "osDisk": {
                         "createOption": "FromImage",
-                        "diskSizeGB": 256,
+                        "diskSizeGB": 1024,
                         "managedDisk": {
                             "storageAccountType": "[parameters('moodleCommon').osDiskStorageType]"
                         },

--- a/nested/webvmss.json
+++ b/nested/webvmss.json
@@ -112,7 +112,7 @@
                         "osDisk": {
                             "caching": "ReadOnly",
                             "createOption": "FromImage",
-                            "diskSizeGB": 256,
+                            "diskSizeGB": 1024,
                             "managedDisk": {
                                 "storageAccountType": "[parameters('moodleCommon').osDiskStorageType]"
                             }

--- a/nested/webvmss.json
+++ b/nested/webvmss.json
@@ -112,6 +112,7 @@
                         "osDisk": {
                             "caching": "ReadOnly",
                             "createOption": "FromImage",
+                            "diskSizeGB": 256,
                             "managedDisk": {
                                 "storageAccountType": "[parameters('moodleCommon').osDiskStorageType]"
                             }

--- a/scripts/install_moodle.sh
+++ b/scripts/install_moodle.sh
@@ -833,6 +833,7 @@ EOF
 
     # use /tmp/localcache/ for localcache
     sed -i "22 a \$CFG->localcachedir = '/tmp/localcache';" /moodle/html/moodle/config.php
+    sed -i "22 a \$CFG->alternative_component_cache = '/tmp/localcachedir/core_component.php';" /moodle/html/moodle/config.php
 
     if [ "$redisAuth" != "None" ]; then
         create_redis_configuration_in_moodledata_muc_config_php

--- a/scripts/install_moodle.sh
+++ b/scripts/install_moodle.sh
@@ -831,6 +831,9 @@ EOF
 
     echo -e "\n\rDone! Installation completed!\n\r"
 
+    # use /tmp/localcache/ for localcache
+    sed -i "22 a \$CFG->localcachedir = '/tmp/localcache';" /moodle/html/moodle/config.php
+
     if [ "$redisAuth" != "None" ]; then
         create_redis_configuration_in_moodledata_muc_config_php
 


### PR DESCRIPTION
This PR mitigates performance and some reliability issues which we have identified during load testing via the following changes:

- Sets the Moodle [localcachedir](https://docs.moodle.org/39/en/Server_cluster#.24CFG-.3Elocalcachedir) to `/tmp/localcache`
- Sets `alternative_component_cache` to `/tmp/localcachedir/core_component.php` (note: I am testing a change around this at present)
- Increases default osDisk size from 30Gb (120 IOPS/3,500 Burst IOPs/25MB/sec) to 1024Gb (5,000 IOPS/200MB/sec) (see: <https://docs.microsoft.com/en-us/azure/virtual-machines/disks-types#premium-ssd> ) for increased IOPS and throughput. 256Gb (1,100 IOPS/3,500 Burst IOPs/125MB/sec) was another option we considered.
- Defaults Load Balancer and Public IP to the [Standard SKU](https://docs.microsoft.com/en-us/azure/load-balancer/skus) for better metrics.

This is a Draft/WIP PR. I am testing this against the current master with a tweak to the location of `alternative_component_cache`.