### PR TITLE
Update the default version of Moodle to 3.9

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -117,7 +117,7 @@
                 "MOODLE_39_STABLE",
                 "MOODLE_38_STABLE"
             ],
-            "defaultValue": "MOODLE_38_STABLE",
+            "defaultValue": "MOODLE_39_STABLE",
             "metadata": {
                 "description": "The Moodle version you want to install."
             },


### PR DESCRIPTION
This pull request updates the default version of Moodle to 3.9.