### PR TITLE
Fixing Moodle directory permissions

### DIFF
--- a/scripts/install_moodle.sh
+++ b/scripts/install_moodle.sh
@@ -839,6 +839,8 @@ EOF
     sed -i "22 a \$CFG->localcachedir = '/tmp/localcachedir';" /moodle/html/moodle/config.php
     sed -i "22 a \$CFG->alternative_component_cache = '/var/www/html/moodle/core_component.php';" /moodle/html/moodle/config.php
     chown -R www-data:www-data $dir
+    chgrp www-data $dir
+    chmod g+s $dir
     
     if [ "$redisAuth" != "None" ]; then
         create_redis_configuration_in_moodledata_muc_config_php


### PR DESCRIPTION
After installing Moodle we are setting the local root directory of the
application to be used for caching certain files. Those files need to be owned by www-data.