### PR TITLE
Update azuredeploy-minimal.json

### DIFF
--- a/azuredeploy-minimal.json
+++ b/azuredeploy-minimal.json
@@ -26,7 +26,7 @@
     "resources": [
         {
             "type": "Microsoft.Resources/deployments",
-            "apiVersion": "2017-05-10",
+            "apiVersion": "2021-01-01",
             "name": "mainTemplate",
             "properties": {
                 "mode": "Incremental",


### PR DESCRIPTION
Create or Update Virtual Network Error:

Resource /subscriptions/418cbac1-78df-47bd-ba17-b1276eea7ace/resourceGroups/Moodle_RG/providers/Microsoft.Network/virtualNetworks/vnet-s742lo/subnets/db-subnet-s742lo cannot be updated using API version 2017-10-01 since it uses the property Delegations which has been set using a higher API version 2018-04-01. Please use api version greater than or equal to 2018-04-01 to update the resource.

I've requested to change the date from 2017-05-10 to 2021-01-01, this date showed that it was supported.