### PR TITLE
Use 'deployment group' instead of deprecated 'group deployment'

### DIFF
--- a/docs/Deploy.md
+++ b/docs/Deploy.md
@@ -76,7 +76,7 @@ Now that we have a resource group and a configuration file we can
 create the cluster itself. This is done with a single command:
 
 ```
-az group deployment create --name $MOODLE_DEPLOYMENT_NAME --resource-group $MOODLE_RG_NAME --template-file $MOODLE_AZURE_WORKSPACE/arm_template/azuredeploy.json --parameters $MOODLE_AZURE_WORKSPACE/$MOODLE_RG_NAME/azuredeploy.parameters.json
+az deployment group create --name $MOODLE_DEPLOYMENT_NAME --resource-group $MOODLE_RG_NAME --template-file $MOODLE_AZURE_WORKSPACE/arm_template/azuredeploy.json --parameters $MOODLE_AZURE_WORKSPACE/$MOODLE_RG_NAME/azuredeploy.parameters.json
 ```
 
 ## Using the created stack

--- a/docs/Get-Install-Data.md
+++ b/docs/Get-Install-Data.md
@@ -39,14 +39,14 @@ The available output parameters are:
 To get a complete list of outputs in json format use:
 
 ```bash
-az group deployment show --resource-group $MOODLE_RG_NAME --name $MOODLE_DEPLOYMENT_NAME --out json --query *.outputs
+az deployment group show --resource-group $MOODLE_RG_NAME --name $MOODLE_DEPLOYMENT_NAME --out json --query *.outputs
 ```
 
 Individual outputs can be retrieved by filtering, for example, to get
 just the value of the `siteURL` use:
 
 ``` bash
-az group deployment show --resource-group $MOODLE_RG_NAME --name $MOODLE_DEPLOYMENT_NAME --out json --query *.outputs.siteURL.value
+az deployment group show --resource-group $MOODLE_RG_NAME --name $MOODLE_DEPLOYMENT_NAME --out json --query *.outputs.siteURL.value
 ```
 
 However, since we are reqeusting JSON output (the default) the value
@@ -54,13 +54,13 @@ is enclosed in quotes. In order to remove these we can output as a tab
 separated list (TSV):
 
 ``` bash
-az group deployment show --resource-group $MOODLE_RG_NAME --name $MOODLE_DEPLOYMENT_NAME --out tsv --query *.outputs.siteURL
+az deployment group show --resource-group $MOODLE_RG_NAME --name $MOODLE_DEPLOYMENT_NAME --out tsv --query *.outputs.siteURL
 ```
 
 Now we can assign individual values to environment variables, for example:
 
 ``` bash
-MOODLE_SITE_URL="$(az group deployment show --resource-group $MOODLE_RG_NAME --name $MOODLE_DEPLOYMENT_NAME --out tsv --query *.outputs.siteURL.value)"
+MOODLE_SITE_URL="$(az deployment group show --resource-group $MOODLE_RG_NAME --name $MOODLE_DEPLOYMENT_NAME --out tsv --query *.outputs.siteURL.value)"
 ```
 
 ### Retrieving Moodle Site URL
@@ -73,7 +73,7 @@ default "www.example.org" you will need to retrieve this value from
 Azure using the following command:
 
 ```bash
-MOODLE_SITE_URL="$(az group deployment show --resource-group $MOODLE_RG_NAME --name $MOODLE_DEPLOYMENT_NAME --out tsv --query *.outputs.siteURL.value)"
+MOODLE_SITE_URL="$(az deployment group show --resource-group $MOODLE_RG_NAME --name $MOODLE_DEPLOYMENT_NAME --out tsv --query *.outputs.siteURL.value)"
 ```
 
 #### Retrieving Moodle Site Load Balancer URL
@@ -84,7 +84,7 @@ ensure that you configure your DNS entry for site URL to point at the
 load balancer.
 
 ```bash
-MOODLE_LOAD_BALANCER_DNS="$(az group deployment show --resource-group $MOODLE_RG_NAME --name $MOODLE_DEPLOYMENT_NAME --out tsv --query *.outputs.loadBalancerDNS.value)"
+MOODLE_LOAD_BALANCER_DNS="$(az deployment group show --resource-group $MOODLE_RG_NAME --name $MOODLE_DEPLOYMENT_NAME --out tsv --query *.outputs.loadBalancerDNS.value)"
 ```
 
 ### Retrieving Moodle Administrator Password
@@ -92,7 +92,7 @@ MOODLE_LOAD_BALANCER_DNS="$(az group deployment show --resource-group $MOODLE_RG
 Moodle admin password (username is "admin"):
 
 ```bash
-MOODLE_ADMIN_PASSWORD="$(az group deployment show --resource-group $MOODLE_RG_NAME --name $MOODLE_DEPLOYMENT_NAME --out tsv --query *.outputs.moodleAdminPassword.value)"
+MOODLE_ADMIN_PASSWORD="$(az deployment group show --resource-group $MOODLE_RG_NAME --name $MOODLE_DEPLOYMENT_NAME --out tsv --query *.outputs.moodleAdminPassword.value)"
 ```
 
 ### Retriving Controller Virtual Machine Details
@@ -100,7 +100,7 @@ MOODLE_ADMIN_PASSWORD="$(az group deployment show --resource-group $MOODLE_RG_NA
 The controller VM runs management tasks for the cluster, such as cron jobs and syslog.
 
 ```bash
-MOODLE_CONTROLLER_INSTANCE_IP="$(az group deployment show --resource-group $MOODLE_RG_NAME --name $MOODLE_DEPLOYMENT_NAME --out tsv --query *.outputs.controllerInstanceIP.value)"
+MOODLE_CONTROLLER_INSTANCE_IP="$(az deployment group show --resource-group $MOODLE_RG_NAME --name $MOODLE_DEPLOYMENT_NAME --out tsv --query *.outputs.controllerInstanceIP.value)"
 ```
 
 There is no username and password for this VM since a username and SSH
@@ -111,18 +111,18 @@ key are provided as input parameters to the template.
 #### Database URL
 
 ``` bash
-MOODLE_DATABASE_DNS="$(az group deployment show --resource-group $MOODLE_RG_NAME --name $MOODLE_DEPLOYMENT_NAME --out tsv --query *.outputs.databaseDNS.value)"
+MOODLE_DATABASE_DNS="$(az deployment group show --resource-group $MOODLE_RG_NAME --name $MOODLE_DEPLOYMENT_NAME --out tsv --query *.outputs.databaseDNS.value)"
 ```
 #### Database admin username
 
 ``` bash
-MOODLE_DATABASE_ADMIN_USERNAME="$(az group deployment show --resource-group $MOODLE_RG_NAME --name $MOODLE_DEPLOYMENT_NAME --out tsv --query *.outputs.databaseAdminUsername.value)"
+MOODLE_DATABASE_ADMIN_USERNAME="$(az deployment group show --resource-group $MOODLE_RG_NAME --name $MOODLE_DEPLOYMENT_NAME --out tsv --query *.outputs.databaseAdminUsername.value)"
 ```
 
 #### Database admin password
 
 ``` bash
-MOODLE_DATABASE_ADMIN_PASSWORD="$(az group deployment show --resource-group $MOODLE_RG_NAME --name $MOODLE_DEPLOYMENT_NAME --out tsv --query *.outputs.databaseAdminPassword.value)"
+MOODLE_DATABASE_ADMIN_PASSWORD="$(az deployment group show --resource-group $MOODLE_RG_NAME --name $MOODLE_DEPLOYMENT_NAME --out tsv --query *.outputs.databaseAdminPassword.value)"
 ```
 
 ### Retrieving Moodle Application VNET Information
@@ -130,7 +130,7 @@ MOODLE_DATABASE_ADMIN_PASSWORD="$(az group deployment show --resource-group $MOO
 First frontend VM IP:
 
 ``` bash
-MOODLE_FIRST_FRONTEND_VM_IP="$(az group deployment show --resource-group $MOODLE_RG_NAME --name $MOODLE_DEPLOYMENT_NAME --out tsv --query *.outputs.firstFrontendVmIP.value)"
+MOODLE_FIRST_FRONTEND_VM_IP="$(az deployment group show --resource-group $MOODLE_RG_NAME --name $MOODLE_DEPLOYMENT_NAME --out tsv --query *.outputs.firstFrontendVmIP.value)"
 ```
 
 # Validation

--- a/loadtest/loadtest.sh
+++ b/loadtest/loadtest.sh
@@ -110,7 +110,7 @@ function deploy_moodle_with_some_parameters
     eval $cmd || return 1
 
     local deployment_name="${resource_group}-deployment"
-    local cmd="az group deployment create --resource-group $resource_group --name $deployment_name $no_wait_flag --template-uri $template_url --parameters @$parameters_template_file webServerType=$web_server_type autoscaleVmSku=$web_vm_sku dbServerType=$db_server_type mysqlPgresVcores=$db_vcores mysqlPgresStgSizeGB=$db_size_gb fileServerType=$file_server_type fileServerDiskCount=$file_server_disk_count fileServerDiskSize=$file_server_disk_size redisDeploySwitch=$redis_cache sshPublicKey='$ssh_pub_key'"
+    local cmd="az deployment group create --resource-group $resource_group --name $deployment_name $no_wait_flag --template-uri $template_url --parameters @$parameters_template_file webServerType=$web_server_type autoscaleVmSku=$web_vm_sku dbServerType=$db_server_type mysqlPgresVcores=$db_vcores mysqlPgresStgSizeGB=$db_size_gb fileServerType=$file_server_type fileServerDiskCount=$file_server_disk_count fileServerDiskSize=$file_server_disk_size redisDeploySwitch=$redis_cache sshPublicKey='$ssh_pub_key'"
     show_command_to_run $cmd
     eval $cmd
 }
@@ -238,7 +238,7 @@ function run_simple_test_1_on_resource_group
 
     sudo apt update; sudo apt install -y jq
     local deployment="${resource_group}-deployment"
-    local output=$(az group deployment show -g $resource_group -n $deployment)
+    local output=$(az deployment group show -g $resource_group -n $deployment)
     local moodle_host=$(echo $output | jq -r .properties.outputs.siteURL.value)
     local db_host=$(echo $output | jq -r .properties.outputs.databaseDNS.value)
     local moodle_db_user=$(echo $output | jq -r .properties.outputs.moodleDbUsername.value)


### PR DESCRIPTION
```bash
az group deployment create --name $MOODLE_DEPLOYMENT_NAME --resource-group $MOODLE_RG_NAME --template-file $MOODLE_AZURE_WORKSPACE/arm_template/azuredeploy.json --parameters $MOODLE_AZURE_WORKSPACE/$MOODLE_RG_NAME/azuredeploy.parameters.json
This command is implicitly deprecated because command group 'group deployment' is deprecated and will be removed in a future release. Use 'deployment group' instead.
```
https://learn.microsoft.com/en-us/cli/azure/group/deployment?view=azure-cli-latest