### PR TITLE
install_moodle.sh: rotate site logs to prevent disk exhaustion

### DIFF
--- a/scripts/install_moodle.sh
+++ b/scripts/install_moodle.sh
@@ -818,6 +818,20 @@ local1.*   /var/log/sitelogs/moodle/access.log
 local1.err   /var/log/sitelogs/moodle/error.log
 local2.*   /var/log/sitelogs/moodle/cron.log
 EOF
+
+    # Rotate the site logs so they don't grow unbounded and fill the OS disk
+    cat <<EOF > /etc/logrotate.d/moodle-sitelogs
+/var/log/sitelogs/moodle/*.log {
+    daily
+    rotate 14
+    missingok
+    notifempty
+    compress
+    delaycompress
+    copytruncate
+}
+EOF
+
     service rsyslog restart
 
     # Fire off moodle setup


### PR DESCRIPTION
The template writes access/error/cron logs under /var/log/sitelogs/moodle but never rotates them, so they grow unbounded and fill the OS disk
This adds a logrotate.d config during provisioning: daily, 14 days retained, compressed, copytruncate (no rsyslog signalling needed).